### PR TITLE
Update notification banner at top of page to v2.1.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
   <body>
     <div class="notification">
-      <a href="https://github.com/basecamp/omarchy/releases/tag/v2.0.0">Omarchy 2.0 has been released!</a>
+      <a href="https://github.com/basecamp/omarchy/releases/tag/v2.1.1">Omarchy 2.1.1 has been released!</a>
     </div>
     <main class="main">
 <pre class="pre">


### PR DESCRIPTION
The notification at the top of the page still references the 2.0.0 launch from a couple weeks ago. This commit updates the notification to the most recent v2.1.1 release.