### PR TITLE
Add anchor links to manual subheaders

### DIFF
--- a/assets/css/manual.css
+++ b/assets/css/manual.css
@@ -71,6 +71,26 @@
   font-size: 110%;
 }
 
+.manual__heading-link {
+  color: var(--color-terminal-cyan);
+  font-size: 0.75em;
+  margin-left: 0.15em;
+  opacity: 0.5;
+  text-decoration: none;
+  transition: opacity var(--transition);
+}
+
+@media(hover: hover) {
+  .manual__heading-link {
+    opacity: 0;
+  }
+
+  .manual__content :is(h2, h3, h4, h5, h6):hover .manual__heading-link,
+  .manual__heading-link:focus-visible {
+    opacity: 0.5;
+  }
+}
+
 .manual__content p,
 .manual__content ul,
 .manual__content ol,

--- a/bin/build-manual
+++ b/bin/build-manual
@@ -59,7 +59,11 @@ def render_markdown(chapter)
     .gsub(/\]\((\d\d)-([\w-]+)\.md(#[^)]*)?\)/) { $1 == "01" ? "](../#{$3})" : "](../#{$2}/#{$3})" }
     .gsub("](images/", "](/manual/images/")
     .gsub(THEME_PREVIEW_REF) { "](/manual/images/#{$1}-#{$2}.webp)" }
-  Kramdown::Document.new(markdown, input: "GFM", hard_wrap: false, syntax_highlighter: nil).to_html
+  html = Kramdown::Document.new(markdown, input: "GFM", hard_wrap: false, syntax_highlighter: nil).to_html
+  html.gsub(/<h([2-6]) id="([^"]+)">(.*?)<\/h\1>/m) do
+    level, id, content = $1, $2, $3
+    %(<h#{level} id="#{id}">#{content} <a class="manual__heading-link" href="##{id}" aria-label="Link to this section">#</a></h#{level}>)
+  end
 end
 
 def h(text) = CGI.escapeHTML(text)

--- a/manual/ai/index.html
+++ b/manual/ai/index.html
@@ -163,7 +163,7 @@
 
 <p>To wrap an additional CLI the same way, run <code>omarchy-mise-install &lt;package&gt; [command-name]</code>. The stubs are kept current along with everything else mise manages when you run <code>omarchy update</code> (or the <code>mup</code> alias).</p>
 
-<h3 id="the-default-agent">The default agent</h3>
+<h3 id="the-default-agent">The default agent <a class="manual__heading-link" href="#the-default-agent" aria-label="Link to this section">#</a></h3>
 
 <p>Pick your default agent with <code>omarchy default agent &lt;name&gt;</code> or under <em>Setup &gt; Defaults &gt; Agent</em> in the Omarchy Menu (<code>Super + Space</code>). If the agent isn’t installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.</p>
 
@@ -171,27 +171,27 @@
 
 <p>There are terminal shortcuts too: <code>a</code> runs the default agent inline in the current terminal, while <code>c</code>, <code>cx</code>, and <code>cy</code> start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, and OpenCode all follow along when you switch the Omarchy theme.</p>
 
-<h3 id="the-agents-panel">The agents panel</h3>
+<h3 id="the-agents-panel">The agents panel <a class="manual__heading-link" href="#the-agents-panel" aria-label="Link to this section">#</a></h3>
 
 <p>The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.</p>
 
 <p>Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by <code>omarchy agent usage-update</code>, and the panel can even merge usage from your other machines via a synced folder. See the README under <code>$OMARCHY_PATH/shell/plugins/agents/</code> for the full settings.</p>
 
-<h3 id="crash-diagnosis">Crash diagnosis</h3>
+<h3 id="crash-diagnosis">Crash diagnosis <a class="manual__heading-link" href="#crash-diagnosis" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy watches systemd-coredump for process crashes. When something segfaults, you’ll get a “Process crashed” notification — click it, and the crash is handed to your default agent along with Omarchy’s diagnose-crash skill, which walks the agent through establishing the facts from the core dump and deciding whether the crash is worth reporting upstream. You can also run it by hand against any PID from <code>coredumpctl list</code> with <code>omarchy agent crash &lt;pid&gt;</code>.</p>
 
 <p>The watching is on by default. Turn it off under <em>Trigger &gt; Toggle &gt; Crash Capture</em> (or with <code>omarchy toggle crash-capture</code>) and the notifications stop; <code>omarchy agent crash &lt;pid&gt;</code> still works by hand.</p>
 
-<h3 id="desktop-apps">Desktop apps</h3>
+<h3 id="desktop-apps">Desktop apps <a class="manual__heading-link" href="#desktop-apps" aria-label="Link to this section">#</a></h3>
 
 <p>The <em>Install &gt; AI</em> menu also carries a couple of graphical AI apps: the ChatGPT desktop app, and Grok Bot for chatting with xAI’s models.</p>
 
-<h3 id="local-llms">Local LLMs</h3>
+<h3 id="local-llms">Local LLMs <a class="manual__heading-link" href="#local-llms" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy recommends two ways of running local LLM models: LM Studio and Ollama. LM Studio provides a GUI interface for finding open-weight models, installing them, and running them. It’s a great way to get going easily. Ollama offers a CLI for doing so similarly. But if you’re new to local models, I’d start with LM Studio. You can install either under <em>Install &gt; AI</em> in the Omarchy Menu.</p>
 
-<h3 id="the-omarchy-skill">The Omarchy Skill</h3>
+<h3 id="the-omarchy-skill">The Omarchy Skill <a class="manual__heading-link" href="#the-omarchy-skill" aria-label="Link to this section">#</a></h3>
 
 <p>Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It’s symlinked into the skill directories for Claude Code (<code>~/.claude/skills</code>), Codex (<code>~/.codex/skills</code>), Pi (<code>~/.pi/agent/skills</code>), and the generic <code>~/.agents/skills</code> location, so most harnesses pick it up automatically.</p>
 

--- a/manual/branding/index.html
+++ b/manual/branding/index.html
@@ -114,7 +114,7 @@
       <h1>Branding</h1>
 <p>Omarchy allows you to set your company logo or personal image for both the boot unlock, the screensaver, and the about screen.</p>
 
-<h3 id="boot-unlock">Boot unlock</h3>
+<h3 id="boot-unlock">Boot unlock <a class="manual__heading-link" href="#boot-unlock" aria-label="Link to this section">#</a></h3>
 
 <p>You can use <code>omarchy plymouth preview</code> to see what your custom logo and colors would look like. It takes a background color, a text color, a logo png, and a path for the preview image:</p>
 
@@ -125,7 +125,7 @@
 
 <p><img src="/manual/images/branding-plymouth-shopify.webp" alt="branding-plymouth-shopify" /></p>
 
-<h3 id="screensaver">Screensaver</h3>
+<h3 id="screensaver">Screensaver <a class="manual__heading-link" href="#screensaver" aria-label="Link to this section">#</a></h3>
 
 <p>You can change the logo used for the screensaver under <em>Style &gt; Screensaver</em>. It’s an ASCII logo, so you can edit the text directly, but you can also hand it a png or svg image, and we’ll convert that to ASCII. It looks pretty cool.</p>
 
@@ -139,13 +139,13 @@
   <li><strong>Restore Default</strong> puts the Omarchy logo back.</li>
 </ul>
 
-<h3 id="about-screen">About screen</h3>
+<h3 id="about-screen">About screen <a class="manual__heading-link" href="#about-screen" aria-label="Link to this section">#</a></h3>
 
 <p>The same three options are under <em>Style &gt; About</em> for the <em>About</em> screen you get from the Omarchy menu, and they work identically — the file is <code>~/.config/omarchy/branding/about.txt</code>, and the About window pops up after each change. The About art is converted to a smaller size than the screensaver’s, since it has to fit in a window rather than fill your display.</p>
 
 <p><img src="/manual/images/branding-about.webp" alt="branding-about" /></p>
 
-<h3 id="converting-images-yourself">Converting images yourself</h3>
+<h3 id="converting-images-yourself">Converting images yourself <a class="manual__heading-link" href="#converting-images-yourself" aria-label="Link to this section">#</a></h3>
 
 <p>Both of the <em>Set From Image</em> options are just calling <code>omarchy transcode ascii</code>, which you can run directly if you want control over the conversion:</p>
 

--- a/manual/browsers/index.html
+++ b/manual/browsers/index.html
@@ -116,7 +116,7 @@
 
 <p>If Chromium isn’t your taste, you’re not stuck with it. Under <em>Install &gt; Browser</em> in the Omarchy menu you’ll find Chrome, Edge, Brave, Brave Origin, Firefox, and <a href="https://zen-browser.app/">Zen</a>. Pick one and Omarchy installs it, sets up its policy directory, and applies your current theme to it.</p>
 
-<h2 id="making-one-the-default">Making one the default</h2>
+<h2 id="making-one-the-default">Making one the default <a class="manual__heading-link" href="#making-one-the-default" aria-label="Link to this section">#</a></h2>
 
 <p>Installing a browser doesn’t promote it. Once it’s on the machine, go to <em>Setup &gt; Defaults &gt; Browser</em> and pick it — the menu only lists browsers you actually have installed, and marks the current default with a check.</p>
 
@@ -127,7 +127,7 @@
 
 <p>Run it with no argument and it tells you the current default. This sets the XDG handler, so it’s not just Omarchy’s hotkeys that follow along — anything that opens a link, from a chat app to a terminal command, goes to the browser you picked.</p>
 
-<h2 id="copy-url-and-download-video">Copy URL and Download Video</h2>
+<h2 id="copy-url-and-download-video">Copy URL and Download Video <a class="manual__heading-link" href="#copy-url-and-download-video" aria-label="Link to this section">#</a></h2>
 
 <p>The Chromium-family browsers (Chromium itself, Chrome, Edge, and Brave) come with two Omarchy extensions that reach out of the browser and into the rest of your system.</p>
 
@@ -139,13 +139,13 @@
 
 <p>These are Chromium-family only. Firefox and Zen don’t get them.</p>
 
-<h2 id="firefox-and-zen">Firefox and Zen</h2>
+<h2 id="firefox-and-zen">Firefox and Zen <a class="manual__heading-link" href="#firefox-and-zen" aria-label="Link to this section">#</a></h2>
 
 <p>Firefox and Zen are a different family, so they get different treatment: Omarchy installs a policies file for sensible defaults and switches them into native Wayland mode, which you want for fractional scaling and smooth trackpad scrolling.</p>
 
 <p>They don’t get the Chromium extensions above, and they’re not themed by Omarchy, so those parts of the experience are yours to set up.</p>
 
-<h2 id="removing-one-again">Removing one again</h2>
+<h2 id="removing-one-again">Removing one again <a class="manual__heading-link" href="#removing-one-again" aria-label="Link to this section">#</a></h2>
 
 <p>Anything you installed here can be taken back off under <em>Remove &gt; Browser</em>. Chromium isn’t in that list — it’s part of the base system.</p>
 

--- a/manual/coming-from-mac-or-windows/index.html
+++ b/manual/coming-from-mac-or-windows/index.html
@@ -114,17 +114,17 @@
       <h1>Coming From Mac or Windows</h1>
 <p>If you’ve spent years on macOS or Windows, your fingers know a hundred things your brain has forgotten it ever learned. This chapter is the translation layer: where those instincts go in Omarchy. The features themselves are covered in depth elsewhere — this is just the map.</p>
 
-<h3 id="super-is-the-center-of-everything">Super is the center of everything</h3>
+<h3 id="super-is-the-center-of-everything">Super is the center of everything <a class="manual__heading-link" href="#super-is-the-center-of-everything" aria-label="Link to this section">#</a></h3>
 
 <p>All the muscle memory you’ve built around Cmd or the Windows key transfers to one key: Super. That’s the Windows key on a PC keyboard, and it’s the anchor for nearly every hotkey in Omarchy.</p>
 
 <p>Your Spotlight or Raycast or Start-menu reflex becomes <code>Super + Space</code>. That opens the Omarchy menu, which launches apps, changes settings, installs software, captures the screen — just about everything. Start typing to filter. There’s also a dedicated apps-only menu on <code>Super + Alt + Space</code>. See <a href="../navigation/">navigation</a>.</p>
 
-<h3 id="theres-no-dock-and-no-desktop-icons">There’s no dock and no desktop icons</h3>
+<h3 id="theres-no-dock-and-no-desktop-icons">There’s no dock and no desktop icons <a class="manual__heading-link" href="#theres-no-dock-and-no-desktop-icons" aria-label="Link to this section">#</a></h3>
 
 <p>Nothing to click to launch things, no icons to arrange on the desktop. Apps start from a hotkey (<code>Super + Return</code> for the terminal, <code>Super + Shift + Return</code> for the browser, and <code>Super + K</code> for a list of everything that’s mapped) or from the menu. The one persistent piece of UI is <a href="../the-top-bar/">the top bar</a>, which covers what the menu bar, system tray, and Notification Center did for you before — and nearly every widget on it does something on left, right, and middle click.</p>
 
-<h3 id="windows-place-themselves">Windows place themselves</h3>
+<h3 id="windows-place-themselves">Windows place themselves <a class="manual__heading-link" href="#windows-place-themselves" aria-label="Link to this section">#</a></h3>
 
 <p>The biggest mindset shift: you don’t drag windows around or snap them to screen halves. Open a window and it takes the whole screen. Open a second and they split it. You never fish a window out from under another one, because windows don’t overlap.</p>
 
@@ -132,13 +132,13 @@
 
 <p>Workspaces will feel familiar: they’re macOS Spaces or Windows virtual desktops, except you’ll actually use them, because <code>Super + 1/2/3/4</code> jumps straight to one and <code>Super + Shift + 1/2/3/4</code> sends the active window there. No animation delay, just instant jumps. This means that you might not even need multiple monitors, if you were used to that before.</p>
 
-<h3 id="copy-and-paste-just-work">Copy and paste just work</h3>
+<h3 id="copy-and-paste-just-work">Copy and paste just work <a class="manual__heading-link" href="#copy-and-paste-just-work" aria-label="Link to this section">#</a></h3>
 
 <p>On the Mac you had Cmd + C everywhere. On Windows you had Ctrl + C everywhere — except the terminal, where it kills your program. Omarchy gives you <code>Super + C</code>, <code>Super + X</code>, and <code>Super + V</code>, and they work everywhere, including the terminal. No separate reflex to learn for the shell.</p>
 
 <p>Windows folks: your Win + V clipboard history lives on <code>Super + Ctrl + V</code>, and it holds images as well as text. See <a href="../unified-clipboard-history/">unified clipboard &amp; history</a>.</p>
 
-<h3 id="the-translation-table">The translation table</h3>
+<h3 id="the-translation-table">The translation table <a class="manual__heading-link" href="#the-translation-table" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -179,7 +179,7 @@
   </tbody>
 </table>
 
-<h3 id="some-things-really-are-different">Some things really are different</h3>
+<h3 id="some-things-really-are-different">Some things really are different <a class="manual__heading-link" href="#some-things-really-are-different" aria-label="Link to this section">#</a></h3>
 
 <p>A lot of settings live in text files you edit, not panels you click through. That sounds primitive until you realize it means every tweak can be seen, copied to your next machine, and put in version control. The <em>Setup</em> menu drops you straight into the right file and restarts whatever needs restarting when you’re done.</p>
 
@@ -189,11 +189,11 @@
 
 <p>And when you close a window, the app actually quits. There’s no macOS limbo where the program keeps running with no windows. <code>Super + W</code> means gone.</p>
 
-<h3 id="on-mac-hardware">On Mac hardware</h3>
+<h3 id="on-mac-hardware">On Mac hardware <a class="manual__heading-link" href="#on-mac-hardware" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy runs well on Intel Macs — see <a href="../mac-support/">Mac support</a>. And the keyboard is kind to you: Omarchy doesn’t remap anything, and Linux treats the Command key as Super, so Super sits right where Cmd always was. Your thumb won’t notice the move.</p>
 
-<h3 id="give-it-two-weeks">Give it two weeks</h3>
+<h3 id="give-it-two-weeks">Give it two weeks <a class="manual__heading-link" href="#give-it-two-weeks" aria-label="Link to this section">#</a></h3>
 
 <p>The instincts transfer faster than you’d think. Skim the <a href="../hotkeys/">hotkeys</a> chapter once, and whenever you blank on a binding, hit <code>Super + K</code> — it shows you all of them. That’s the only hotkey you actually have to memorize.</p>
 

--- a/manual/commercial-apps-services/index.html
+++ b/manual/commercial-apps-services/index.html
@@ -114,37 +114,37 @@
       <h1>Commercial apps/services</h1>
 <p>Omarchy is mostly focused on providing free, open source software, but it’s not religious about it. Sometimes the best solution is a commercial offering, and that’s just fine. Here are some of the options we provide an easy installation for.</p>
 
-<h2 id="1password">1Password</h2>
+<h2 id="1password">1Password <a class="manual__heading-link" href="#1password" aria-label="Link to this section">#</a></h2>
 
 <p>Keeping your passwords in a password manager is a best practice. Doubly so if you’re working with a team. And <a href="https://1password.com/">1password</a> is a great solution, which also comes with a command line tool for integrating key lookups in scripts.</p>
 
 <p>You start 1Password with <code>Super + Shift + /</code>. If it isn’t installed yet, that hotkey kicks off the installation first (you can also use <em>Install &gt; Service &gt; 1Password</em> from the Omarchy menu). The installer sets up the 1Password extension for Chromium as well.</p>
 
-<h2 id="bitwarden">Bitwarden</h2>
+<h2 id="bitwarden">Bitwarden <a class="manual__heading-link" href="#bitwarden" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://bitwarden.com/">Bitwarden</a> is the open source alternative in the password manager space, with a free tier that covers most personal use. Install it with <em>Install &gt; Service &gt; Bitwarden</em> from the Omarchy menu, which brings along the Bitwarden command line tool as well.</p>
 
-<h2 id="spotify">Spotify</h2>
+<h2 id="spotify">Spotify <a class="manual__heading-link" href="#spotify" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://spotify.com/">Spotify</a> is the world’s most popular streaming music service. And the Linux application provides everything you’d expect, including offline playing.</p>
 
 <p>You start Spotify using <code>Super + Shift + M</code>. Like 1Password, the hotkey kicks off the installation first if Spotify isn’t installed yet (or use <em>Install &gt; Service &gt; Spotify</em> from the Omarchy menu).</p>
 
-<h2 id="dropbox">Dropbox</h2>
+<h2 id="dropbox">Dropbox <a class="manual__heading-link" href="#dropbox" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.dropbox.com/">Dropbox</a> is a great way to sync files between machines while keeping a backup in the cloud. To set it up, select <em>Install &gt; Service &gt; Dropbox</em> from the Omarchy menu. Once it’s running, hover the tray in the top right of the bar and right-click the Dropbox icon to finish the setup.</p>
 
-<h2 id="tailscale">Tailscale</h2>
+<h2 id="tailscale">Tailscale <a class="manual__heading-link" href="#tailscale" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://tailscale.com/">Tailscale</a> is a mesh VPN that makes getting access to all your computers and servers over the internet securely super simple. To set it up, select <em>Install &gt; Service &gt; Tailscale</em> from the Omarchy menu.</p>
 
 <p>It gets a panel in the bar, a web app for the admin console, and Taildrop for sending files between your machines — see <a href="../networking/">networking</a>.</p>
 
-<h2 id="once">ONCE</h2>
+<h2 id="once">ONCE <a class="manual__heading-link" href="#once" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://once.com/">ONCE</a> is 37signals’ line of software you buy once and run on your own server, like the Campfire chat system. Select <em>Install &gt; Service &gt; ONCE</em> from the Omarchy menu to install it, which enables its background service and drops you into the ONCE terminal interface to take it from there.</p>
 
-<h2 id="nordvpn">NordVPN</h2>
+<h2 id="nordvpn">NordVPN <a class="manual__heading-link" href="#nordvpn" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://nordvpn.com/">NordVPN</a> is a standard VPN service that lets you exit your traffic from most regions around the world. To set it up, select <em>Install &gt; Service &gt; NordVPN</em> from the Omarchy menu. After the reboot it asks for, run <code>nordvpn login</code> to authenticate.</p>
 

--- a/manual/common-tweaks/index.html
+++ b/manual/common-tweaks/index.html
@@ -116,11 +116,11 @@
 
 <p>If you screw something up, you can restore individual configs to their original setup via <em>Update &gt; Config</em> in the Omarchy menu. If you <em>really</em> screw everything up, you can reset all configs via <code>omarchy-reinstall</code>.</p>
 
-<h3 id="reveal-all-tray-icons-all-the-time">Reveal all tray icons all the time</h3>
+<h3 id="reveal-all-tray-icons-all-the-time">Reveal all tray icons all the time <a class="manual__heading-link" href="#reveal-all-tray-icons-all-the-time" aria-label="Link to this section">#</a></h3>
 
 <p>By default, tray icons, like Dropbox, 1password, or Steam, are hidden behind the tray expander arrow, which reveals them when you hover it. If you’d like to have them exposed all the time, right-click the expander arrow to open the tray icon manager, then pin the icons you want to keep visible (you can also hide the ones you never want to see).</p>
 
-<h3 id="rounded-window-corners">Rounded window corners</h3>
+<h3 id="rounded-window-corners">Rounded window corners <a class="manual__heading-link" href="#rounded-window-corners" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy’s default design is one of square corners, but if you like to soften that up a bit, you can change <code>~/.config/hypr/looknfeel.lua</code> so rounding is no longer commented out:</p>
 
@@ -132,7 +132,7 @@
 })
 </code></pre>
 
-<h3 id="remove-window-gaps">Remove window gaps</h3>
+<h3 id="remove-window-gaps">Remove window gaps <a class="manual__heading-link" href="#remove-window-gaps" aria-label="Link to this section">#</a></h3>
 
 <p>On laptop displays, some people prefer not to waste any pixels on window gaps (or even a top bar, which you can toggle off with <code>Super + Shift + Space</code>). You can toggle all gaps and borders off with <code>Super + Shift + Backspace</code>, or remove them permanently by removing the comments in this section of <code>~/.config/hypr/looknfeel.lua</code>:</p>
 

--- a/manual/development-tools/index.html
+++ b/manual/development-tools/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>Development Tools</h1>
-<h2 id="alternative-editors">Alternative Editors</h2>
+<h2 id="alternative-editors">Alternative Editors <a class="manual__heading-link" href="#alternative-editors" aria-label="Link to this section">#</a></h2>
 
 <p>Omarchy ships with <a href="https://neovim.io/">Neovim</a> by default, but if you’d like something a bit more mainstream and familiar, you can run the Omarchy Menu (<code>Super + Space</code>) and see the options under <em>Install &gt; Editor</em>. We have VSCode, Cursor, Zed, Sublime Text, Helix, Vim, and Emacs listed there. If you don’t find what you’re looking for, checkout <em>Install &gt; Package</em>, and see if it isn’t in an Arch package (and if not, try <em>Install &gt; AUR</em> to check the AUR).</p>
 
@@ -120,7 +120,7 @@
 
 <p>You can set the system-wide default editor under <code>Setup &gt; Defaults &gt; Editor</code>.</p>
 
-<h2 id="environment">Environment</h2>
+<h2 id="environment">Environment <a class="manual__heading-link" href="#environment" aria-label="Link to this section">#</a></h2>
 
 <p>Omarchy supports setting up a whole host of development environments through the <em>Install &gt; Development</em> section of the Omarchy Menu (<code>Super + Space</code>). You’ll of course find <em>Ruby on Rails</em>, but also all three major runtimes for JavaScript (Node.js, Bun, Deno), as well as popular PHP frameworks like Laravel and Symfony. Oh, and there’s Go, Rust, Python, Java, Elixir (with Phoenix), .NET, OCaml, Zig, Clojure, and Scala too. It’s a very broad selection!</p>
 
@@ -128,7 +128,7 @@
 
 <p>To install, say, Ruby, you’d run <code>mise use -g ruby</code>, which will both install Ruby and set it as the global default. Or, if your project has a .ruby-version file, you can just run <code>mise i</code> in the root of that project.</p>
 
-<h2 id="docker">Docker</h2>
+<h2 id="docker">Docker <a class="manual__heading-link" href="#docker" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.docker.com/">Docker</a> hardly needs any introduction. It allows you to run isolated containers, and Omarchy installs everything needed to run it well. This includes Docker itself, <a href="https://docs.docker.com/compose/">Docker Compose</a>, and the user group changes needed for you to run Docker as the normal user and not as root.</p>
 
@@ -136,7 +136,7 @@
 
 <p>You can setup the common databases for local development in Docker using <em>Install &gt; Development &gt; Docker DB</em> in the Omarchy menu.</p>
 
-<h2 id="github-cli">GitHub CLI</h2>
+<h2 id="github-cli">GitHub CLI <a class="manual__heading-link" href="#github-cli" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://cli.github.com/">The GitHub CLI</a> let’s you authenticate with your GitHub account and clone private repositories using it. It’s wired up as one of the lazy-loading mise stubs, so the first time you run <code>gh</code>, it installs itself. To authenticate, run <code>gh auth login</code>. Then you can checkout private repositories using <code>gh repo clone org/repo</code>.</p>
 

--- a/manual/dotfiles/index.html
+++ b/manual/dotfiles/index.html
@@ -167,7 +167,7 @@
 
 <p>If you end up making a lot of changes to tweak your own setup, it’s a good idea to backup all these dotfiles. <a href="https://www.youtube.com/watch?v=NoFiYOqnC4o">Stow is a great way to do that</a>.</p>
 
-<h3 id="starting-your-own-apps-with-the-session">Starting your own apps with the session</h3>
+<h3 id="starting-your-own-apps-with-the-session">Starting your own apps with the session <a class="manual__heading-link" href="#starting-your-own-apps-with-the-session" aria-label="Link to this section">#</a></h3>
 
 <p>If you want something to run every time you log in — a sync daemon, a chat app, your own script — put it in <code>~/.config/hypr/autostart.lua</code>:</p>
 
@@ -176,7 +176,7 @@
 
 <p>That starts the command as part of the session, so it’s properly cleaned up when you log out again.</p>
 
-<h3 id="running-scripts-on-system-events">Running scripts on system events</h3>
+<h3 id="running-scripts-on-system-events">Running scripts on system events <a class="manual__heading-link" href="#running-scripts-on-system-events" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy fires hooks at a handful of moments, and you can hang your own scripts off them. They live in <code>~/.config/omarchy/hooks/&lt;event&gt;.d/</code>, one directory per event, and every executable file in there runs when the event happens:</p>
 
@@ -217,7 +217,7 @@
 
 <p>Each of those directories already holds a <code>.sample</code> file showing the shape of a hook — drop the <code>.sample</code> from the name to put it to work. To install a script you’ve written elsewhere, use <code>omarchy hook install post-boot ~/my-hook</code>, which copies it in and makes it executable.</p>
 
-<h3 id="adding-your-own-menu-entries">Adding your own menu entries</h3>
+<h3 id="adding-your-own-menu-entries">Adding your own menu entries <a class="manual__heading-link" href="#adding-your-own-menu-entries" aria-label="Link to this section">#</a></h3>
 
 <p>The Omarchy menu (<code>Super + Space</code>) can be extended with your own rows by editing <code>~/.config/omarchy/extensions/omarchy-menu.jsonc</code>. Entries are keyed by a dotted id, and the id is what places them in the tree, so <code>personal</code> shows up on the root menu and <code>personal.notes</code> shows up inside it:</p>
 
@@ -227,11 +227,11 @@
 
 <p>Reuse an existing id and you override that row instead of adding a new one. The file ships with all the available fields documented as comments.</p>
 
-<h3 id="adding-your-own-shell-exports-functions-and-aliases">Adding your own shell exports, functions, and aliases</h3>
+<h3 id="adding-your-own-shell-exports-functions-and-aliases">Adding your own shell exports, functions, and aliases <a class="manual__heading-link" href="#adding-your-own-shell-exports-functions-and-aliases" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy ships with a bunch of ergonomic aliases and helpful functions, but it’s very common to want to add your own. You should add both aliases, functions, and exports in <code>~/.bashrc</code>. This file will not be overwritten on updates. If you want to change any of the Omarchy defaults, you can also safely add them here.</p>
 
-<h3 id="changing-internal-omarchy-files">Changing internal Omarchy files</h3>
+<h3 id="changing-internal-omarchy-files">Changing internal Omarchy files <a class="manual__heading-link" href="#changing-internal-omarchy-files" aria-label="Link to this section">#</a></h3>
 
 <p>Look, this is your computer. You can do whatever you want with it, but I would advise against making changes to the files in <code>/usr/share/omarchy</code> directly. They belong to the Omarchy pacman package, so your changes will simply be overwritten on the next update. You’re better off just overwriting any default values you don’t like in the <code>~/.config/*</code> folder instead.</p>
 
@@ -243,7 +243,7 @@ o.bind("SUPER + SHIFT + O", "Joplin", "joplin-desktop")
 
 <p>If you insist on hacking on the internal Omarchy files, switch to the dev channel via <em>Update &gt; Channel &gt; Dev</em>. That links Omarchy to a git checkout of the source code in <code>~/omarchy</code>, which you’re free to change to your heart’s content. Ain’t nobody here to tell you what to do!</p>
 
-<h3 id="resetting-any-changes">Resetting any changes</h3>
+<h3 id="resetting-any-changes">Resetting any changes <a class="manual__heading-link" href="#resetting-any-changes" aria-label="Link to this section">#</a></h3>
 
 <p>If you end up making a mess of the configurations, you can always revert them to the defaults via <em>Update &gt; Config</em> in the Omarchy menu. Or by running <code>omarchy reinstall configs</code> to reset everything.</p>
 

--- a/manual/dual-boot-install/index.html
+++ b/manual/dual-boot-install/index.html
@@ -116,7 +116,7 @@
 
 <p>This installation method still comes with LUKS encryption for the partition by default so it’s effectively no different than full drive and simply requires free space to be available on the disk.</p>
 
-<h2 id="making-space-on-windows">Making Space on Windows</h2>
+<h2 id="making-space-on-windows">Making Space on Windows <a class="manual__heading-link" href="#making-space-on-windows" aria-label="Link to this section">#</a></h2>
 
 <p>To install alongside Windows, type <code>disk management</code> in the start menu and select the option for <strong>Create and format hard disk partitions</strong>.</p>
 
@@ -134,7 +134,7 @@
 
 <p><img src="/manual/images/dual-boot-4.webp" alt="dual-boot-4" /></p>
 
-<h2 id="installing-omarchy">Installing Omarchy</h2>
+<h2 id="installing-omarchy">Installing Omarchy <a class="manual__heading-link" href="#installing-omarchy" aria-label="Link to this section">#</a></h2>
 
 <p>The install process for Omarchy is effectively the same as normal. After you select your disk, you’ll be given the option of <strong>Free space install</strong>. Select that option to prevent wiping the full disk.</p>
 
@@ -143,13 +143,13 @@
 <p>Confirm that everything looks good and wait for the install to finish like normal. This is also where you could elect to install unencrypted (not recommended) just like on a full-drive install.
  <img src="/manual/images/dual-boot-6.webp" alt="dual-boot-6" /></p>
 
-<h2 id="adding-other-installs-to-the-bootloader">Adding Other Installs to the Bootloader</h2>
+<h2 id="adding-other-installs-to-the-bootloader">Adding Other Installs to the Bootloader <a class="manual__heading-link" href="#adding-other-installs-to-the-bootloader" aria-label="Link to this section">#</a></h2>
 
 <p>When you finish your Omarchy install, you’ll notice that the Limine bootloader is the default now. With this, you can also add options to Limine for your other installs such as Windows.</p>
 
 <p>In order to do that, run <code>limine-scan</code> and follow the prompts to add whichever items you’d like to your limine config. Then when you boot, you’ll see your normal options for Omarchy, as well as Windows Boot Manager or others.</p>
 
-<h2 id="bitlocker">Bitlocker</h2>
+<h2 id="bitlocker">Bitlocker <a class="manual__heading-link" href="#bitlocker" aria-label="Link to this section">#</a></h2>
 
 <p>It’s important to note that this install method is not compatible with Bitlocker as it encrypts the entire drive, not just the partition. If you encounter an error stating that Bitlocker is enabled, boot to Windows, go to <strong>Settings -&gt; Privacy &amp; Security -&gt; Device encryption</strong> and toggle Bitlocker off. It may take some time to decrypt the drive.</p>
 

--- a/manual/faq/index.html
+++ b/manual/faq/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>FAQ</h1>
-<h3 id="how-do-i-switch-between-keyboard-layouts">How do I switch between keyboard layouts?</h3>
+<h3 id="how-do-i-switch-between-keyboard-layouts">How do I switch between keyboard layouts? <a class="manual__heading-link" href="#how-do-i-switch-between-keyboard-layouts" aria-label="Link to this section">#</a></h3>
 
 <p>Edit your <code>~/.config/hypr/input.lua</code> file and add this to switch between layouts on <code>Left Alt + Right Alt</code>:</p>
 
@@ -127,7 +127,7 @@
 
 <p>The bar will automatically show your current keyboard layout once you have multiple layouts configured (and you can click it to switch too).</p>
 
-<h3 id="how-do-i-change-the-clock-format-to-12-hour">How do I change the clock format to 12-hour?</h3>
+<h3 id="how-do-i-change-the-clock-format-to-12-hour">How do I change the clock format to 12-hour? <a class="manual__heading-link" href="#how-do-i-change-the-clock-format-to-12-hour" aria-label="Link to this section">#</a></h3>
 
 <p>Right-click the clock in the bar to cycle through the common formats, including the 12-hour ones. You can also set the format directly:</p>
 
@@ -136,27 +136,27 @@
 
 <p>This will display Sunday 10:55 AM.</p>
 
-<h3 id="how-do-i-change-my-timezone">How do I change my timezone?</h3>
+<h3 id="how-do-i-change-my-timezone">How do I change my timezone? <a class="manual__heading-link" href="#how-do-i-change-my-timezone" aria-label="Link to this section">#</a></h3>
 
 <p>Run <em>Update &gt; Timezone</em> in the Omarchy menu and pick from the list. If the timezone is right but the clock itself has drifted, <em>Update &gt; Time</em> restarts the time synchronization for you.</p>
 
-<h3 id="how-do-i-change-my-dns-share-my-wi-fi-or-check-my-connection-speed">How do I change my DNS, share my Wi-Fi, or check my connection speed?</h3>
+<h3 id="how-do-i-change-my-dns-share-my-wi-fi-or-check-my-connection-speed">How do I change my DNS, share my Wi-Fi, or check my connection speed? <a class="manual__heading-link" href="#how-do-i-change-my-dns-share-my-wi-fi-or-check-my-connection-speed" aria-label="Link to this section">#</a></h3>
 
 <p>Those all live in <a href="../networking/">networking</a>.</p>
 
-<h3 id="how-do-i-check-how-fast-my-disk-is">How do I check how fast my disk is?</h3>
+<h3 id="how-do-i-check-how-fast-my-disk-is">How do I check how fast my disk is? <a class="manual__heading-link" href="#how-do-i-check-how-fast-my-disk-is" aria-label="Link to this section">#</a></h3>
 
 <p><em>Trigger &gt; Speed Test &gt; Disk Speed Test</em> measures live read and write speed on your drive, or <code>omarchy disk speedtest</code> from the terminal.</p>
 
-<h3 id="why-cant-i-sign-into-my-google-account-in-chromium">Why can’t I sign into my Google account in Chromium?</h3>
+<h3 id="why-cant-i-sign-into-my-google-account-in-chromium">Why can’t I sign into my Google account in Chromium? <a class="manual__heading-link" href="#why-cant-i-sign-into-my-google-account-in-chromium" aria-label="Link to this section">#</a></h3>
 
 <p>The plain open source Chromium build doesn’t ship with the OAuth credentials that Google requires for account sign-in. Run <em>Install &gt; Service &gt; Chromium Account</em> in the Omarchy menu to add them, restart the browser, and the sign-in will go through.</p>
 
-<h3 id="how-do-i-add-a-printer">How do I add a printer?</h3>
+<h3 id="how-do-i-add-a-printer">How do I add a printer? <a class="manual__heading-link" href="#how-do-i-add-a-printer" aria-label="Link to this section">#</a></h3>
 
 <p>Printing is set up and running out of the box, so a printer on your network is usually already discovered. Launch <em>Print Settings</em> from the app launcher (<code>Super + Space</code>) to see what’s there, add one by hand, or set the default. Printing to a PDF file works without any printer at all.</p>
 
-<h3 id="how-do-i-change-where-screenshots-or-screenrecordings-are-saved">How do I change where screenshots or screenrecordings are saved?</h3>
+<h3 id="how-do-i-change-where-screenshots-or-screenrecordings-are-saved">How do I change where screenshots or screenrecordings are saved? <a class="manual__heading-link" href="#how-do-i-change-where-screenshots-or-screenrecordings-are-saved" aria-label="Link to this section">#</a></h3>
 
 <p>If you want screenshots to be saved to <code>~/Pictures/Screenshots</code> instead of just <code>~/Pictures</code>, you can add this to a file under <code>~/.config/uwsm/env.d/</code> (like <code>~/.config/uwsm/env.d/capture</code>):</p>
 
@@ -167,13 +167,13 @@
 
 <p>Just remember to create the directoy you want to save to and restart Omarchy for this to take effect.</p>
 
-<h3 id="how-do-i-get-the-speakers--webcam-working-on-my-apple-studio-display">How do I get the speakers + webcam working on my Apple Studio Display?</h3>
+<h3 id="how-do-i-get-the-speakers--webcam-working-on-my-apple-studio-display">How do I get the speakers + webcam working on my Apple Studio Display? <a class="manual__heading-link" href="#how-do-i-get-the-speakers--webcam-working-on-my-apple-studio-display" aria-label="Link to this section">#</a></h3>
 
 <p>You’d think that it should all work just plugging in USB C, but unfortunately that isn’t the case. The solution I’ve found to make it work reliably is using <a href="https://www.amazon.com/WJESOG-DisplayPort-Adapter-Converter-Thunderbolt/dp/B0BNX7MS6N/">the WJESOG DisplayPort + USB-A =&gt; USB-C cable</a>. Then speakers and webcam work like a charm.</p>
 
 <p>Remember that you have built-in brightness control in Omarchy for the Apple Displays (both Studio and XDR) using the regular keyboard brightness buttons.</p>
 
-<h3 id="how-do-i-get-rid-of-all-the-extra-software">How do I get rid of all the extra software?</h3>
+<h3 id="how-do-i-get-rid-of-all-the-extra-software">How do I get rid of all the extra software? <a class="manual__heading-link" href="#how-do-i-get-rid-of-all-the-extra-software" aria-label="Link to this section">#</a></h3>
 
 <p>If you don’t want programs like Obsidian or LibreOffice or any of the other preinstalled stuff, you can very easily remove it.</p>
 

--- a/manual/gaming/index.html
+++ b/manual/gaming/index.html
@@ -118,7 +118,7 @@
 
 <p>All gaming installers live under <em>Install &gt; Gaming</em> in the Omarchy menu (<code>Super + Space</code>). If you ever want to undo one, use <em>Remove &gt; Gaming</em>.</p>
 
-<h2 id="steam">Steam</h2>
+<h2 id="steam">Steam <a class="manual__heading-link" href="#steam" aria-label="Link to this section">#</a></h2>
 
 <p>Install <a href="https://store.steampowered.com/">Steam</a> by selecting <em>Install &gt; Gaming &gt; Steam</em> from the Omarchy menu (<code>Super + Space</code>).</p>
 
@@ -128,7 +128,7 @@
 
 <p><img src="/manual/images/gaming-steam.webp" alt="gaming-steam" /></p>
 
-<h2 id="retroarch">RetroArch</h2>
+<h2 id="retroarch">RetroArch <a class="manual__heading-link" href="#retroarch" aria-label="Link to this section">#</a></h2>
 
 <p>Install <a href="https://www.retroarch.com/">RetroArch</a> by selecting <em>Install &gt; Gaming &gt; RetroArch</em> from the Omarchy menu (<code>Super + Space</code>). It comes with the full set of libretro cores, so all the classic systems are covered.</p>
 
@@ -146,7 +146,7 @@
 
 <p><img src="/manual/images/gaming-retroarch.webp" alt="gaming-retroarch" /></p>
 
-<h2 id="xbox-cloud-gaming">Xbox Cloud Gaming</h2>
+<h2 id="xbox-cloud-gaming">Xbox Cloud Gaming <a class="manual__heading-link" href="#xbox-cloud-gaming" aria-label="Link to this section">#</a></h2>
 
 <p>Install the Xbox Cloud Gaming web app by selecting <em>Install &gt; Gaming &gt; Xbox Cloud Gaming</em> from the Omarchy menu (<code>Super + Space</code>). It’s “just” a web app for the service, but it’s quick to start and runs great at 1080p.</p>
 
@@ -154,13 +154,13 @@
 
 <p><img src="/manual/images/gaming-xbox-cloud.webp" alt="gaming-xbox-cloud" /></p>
 
-<h2 id="nvidia-geforce-now">NVIDIA GeForce Now</h2>
+<h2 id="nvidia-geforce-now">NVIDIA GeForce Now <a class="manual__heading-link" href="#nvidia-geforce-now" aria-label="Link to this section">#</a></h2>
 
 <p>Install the cloud-gaming service <a href="https://www.nvidia.com/en-us/geforce-now/">NVIDIA GeForce NOW</a> by selecting <em>Install &gt; Gaming &gt; NVIDIA GeForce NOW</em> from the Omarchy menu (<code>Super + Space</code>). Another great way to play titles that aren’t available natively on Linux.</p>
 
 <p><img src="/manual/images/gaming-geforce-now.webp" alt="gaming-geforce-now" /></p>
 
-<h2 id="minecraft">Minecraft</h2>
+<h2 id="minecraft">Minecraft <a class="manual__heading-link" href="#minecraft" aria-label="Link to this section">#</a></h2>
 
 <p>Install Minecraft by selecting <em>Install &gt; Gaming &gt; Minecraft</em> from the Omarchy menu (<code>Super + Space</code>).</p>
 
@@ -168,11 +168,11 @@
 
 <p><img src="/manual/images/gaming-minecraft.webp" alt="gaming-minecraft" /></p>
 
-<h2 id="xbox-controllers">Xbox Controllers</h2>
+<h2 id="xbox-controllers">Xbox Controllers <a class="manual__heading-link" href="#xbox-controllers" aria-label="Link to this section">#</a></h2>
 
 <p>Install support for Bluetooth Xbox controllers by selecting <em>Install &gt; Gaming &gt; Xbox Controllers</em> from the Omarchy menu (<code>Super + Space</code>). Pair the controllers via Bluetooth (<code>Super + Ctrl + B</code>) and they’ll work in all your games. You don’t need this if you’re just hardwiring your controller with a USB-C cable.</p>
 
-<h2 id="moonlight-game-streaming-from-a-pc">Moonlight (Game streaming from a PC)</h2>
+<h2 id="moonlight-game-streaming-from-a-pc">Moonlight (Game streaming from a PC) <a class="manual__heading-link" href="#moonlight-game-streaming-from-a-pc" aria-label="Link to this section">#</a></h2>
 
 <p>The <a href="https://github.com/moonlight-stream/moonlight-qt">Moonlight client</a> comes preinstalled with Omarchy, so you can stream games from a Windows PC running <a href="https://app.lizardbyte.dev/Sunshine/">Sunshine</a> right away. Launch Moonlight via <code>Super + Space</code>.</p>
 
@@ -180,19 +180,19 @@
 
 <p>You can also turn an Omarchy machine into the host by running <code>omarchy install service sunshine</code>, which installs Sunshine and opens the Moonlight streaming ports for your LAN and Tailscale.</p>
 
-<h2 id="battlenet">Battle.net</h2>
+<h2 id="battlenet">Battle.net <a class="manual__heading-link" href="#battlenet" aria-label="Link to this section">#</a></h2>
 
 <p>Install <a href="https://eu.shop.battle.net/en-us">Battle.net</a> by selecting <em>Install &gt; Gaming &gt; Battle.net</em> from the Omarchy menu (<code>Super + Space</code>). This gives you titles like Diablo, Starcraft, and World of Warcraft as a standalone install running under GE-Proton — no Steam, Lutris, or Heroic needed.</p>
 
 <p><img src="/manual/images/gaming-starcraft.webp" alt="gaming-starcraft" /></p>
 
-<h2 id="lutris-windows-games">Lutris (Windows games)</h2>
+<h2 id="lutris-windows-games">Lutris (Windows games) <a class="manual__heading-link" href="#lutris-windows-games" aria-label="Link to this section">#</a></h2>
 
 <p>Install <a href="https://lutris.net/">Lutris</a> by selecting <em>Install &gt; Gaming &gt; Lutris</em> from the Omarchy menu (<code>Super + Space</code>). Lutris is the way to play Windows games from stores like EA and Ubisoft Connect that don’t have their own installer above.</p>
 
 <p>Installation is a little janky and looks like nothing is happening at times — just be patient, it’s working in the background.</p>
 
-<h2 id="heroic-launcher-epic-games">Heroic Launcher (Epic Games)</h2>
+<h2 id="heroic-launcher-epic-games">Heroic Launcher (Epic Games) <a class="manual__heading-link" href="#heroic-launcher-epic-games" aria-label="Link to this section">#</a></h2>
 
 <p>Install the <a href="https://heroicgameslauncher.com/">Heroic Launcher</a> by selecting <em>Install &gt; Gaming &gt; Heroic (Epic Games)</em> from the Omarchy menu (<code>Super + Space</code>). Heroic lets you run Epic Games titles, like OddSparks, that don’t rely on anti-cheat — plus games from GOG and Amazon Prime Gaming. Sadly, that means no Fortnite and no Rocket League — until Tim Sweeney comes to Linux, this is as close as it gets.</p>
 

--- a/manual/getting-started/index.html
+++ b/manual/getting-started/index.html
@@ -128,25 +128,25 @@
 
 <p>Now you’re ready to Omarchy!</p>
 
-<h3 id="use-a-wired-or-24ghz-keyboard">Use a wired or 2.4ghz keyboard!</h3>
+<h3 id="use-a-wired-or-24ghz-keyboard">Use a wired or 2.4ghz keyboard! <a class="manual__heading-link" href="#use-a-wired-or-24ghz-keyboard" aria-label="Link to this section">#</a></h3>
 
 <p>The full-disk encryption won’t allow you to enter the password from a Bluetooth keyboard at startup. Just like you can’t use a Bluetooth keyboard to enter the BIOS on a PC. You’ll need a keyboard that either uses a 2.4ghz dongle or a cable (which is much nicer for latency anyway!). I personally love the <a href="https://www.lofree.co/products/lofree-flow-the-smoothest-mechanical-keyboard">Lofree Flow84</a>!</p>
 
-<h3 id="installing-for-another-owner">Installing for another owner</h3>
+<h3 id="installing-for-another-owner">Installing for another owner <a class="manual__heading-link" href="#installing-for-another-owner" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re setting up a machine for someone else — a family member, a new employee, a buyer — you shouldn’t be answering the personal questions on their behalf. Hit <code>Ctrl + C</code> on the very first screen of the installer (the keyboard selection), and Omarchy will offer to prepare the machine for another owner instead. The system installs right away, but all the personal setup — keyboard layout, username, password — is deferred until the machine boots for the first time. The drive is still encrypted by default, and the password the new owner picks on that first boot becomes the encryption password too. (A machine you’ve already been using can be handed over without a reinstall too — see <a href="../security/">resetting the computer</a>.)</p>
 
-<h3 id="unattended-installs">Unattended installs</h3>
+<h3 id="unattended-installs">Unattended installs <a class="manual__heading-link" href="#unattended-installs" aria-label="Link to this section">#</a></h3>
 
 <p>The ISO can also install completely on its own — no keyboard, no wizard — when it’s handed its configuration on a second drive. That’s the way to treat Omarchy as a base image for VMs and fleet machines. See <a href="../unattended-installs/">unattended installs</a>.</p>
 
-<h3 id="no-encryption-installations">No-encryption installations</h3>
+<h3 id="no-encryption-installations">No-encryption installations <a class="manual__heading-link" href="#no-encryption-installations" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy is installed with encryption by default. It’s the safe, responsible choice for any computer that can possibly be lost or stolen. You don’t want anyone with access to your hardware to be able to get your data!</p>
 
 <p>But in special circumstances, like remote Omarchy installs on protected computers or for throw-away installations without sensitive data, you may want to install without encryption. You can hit <code>Ctrl + C</code> on the disk formatting confirmation to switch to an encryption-less installation.</p>
 
-<h3 id="help-if-youre-stuck">Help if you’re stuck</h3>
+<h3 id="help-if-youre-stuck">Help if you’re stuck <a class="manual__heading-link" href="#help-if-youre-stuck" aria-label="Link to this section">#</a></h3>
 
 <p>If you get stuck, you can usually find someone willing to help in the <em>#omarchy-help</em> channel on <a href="https://omarchy.org/discord">the community Discord</a>.</p>
 

--- a/manual/guis/index.html
+++ b/manual/guis/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>GUIs</h1>
-<h2 id="files">Files</h2>
+<h2 id="files">Files <a class="manual__heading-link" href="#files" aria-label="Link to this section">#</a></h2>
 
 <p>Files (Nautilus) is the graphical file manager. <code>Super + Shift + F</code> opens it, and <code>Super + Shift + Alt + F</code> opens it in the directory your terminal is sitting in, which saves a lot of clicking. <code>Ctrl + L</code> lets you type a path, and hitting <code>Space</code> on any file gives you a quick preview without opening anything.</p>
 
@@ -120,7 +120,7 @@
 
 <p>Double-clicking follows sensible defaults: images open in imv, video in mpv, PDFs in Document Viewer, and plain text in Neovim.</p>
 
-<h2 id="obsidian">Obsidian</h2>
+<h2 id="obsidian">Obsidian <a class="manual__heading-link" href="#obsidian" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://obsidian.md/">Obsidian</a> is a free and highly extensible note taking application that uses simple Markdown files for storage.</p>
 
@@ -130,25 +130,25 @@
 
 <p>You start Obsidian with <code>Super + Shift + O</code>. To use theme syncing, you must select the <code>Omarchy</code> theme under settings.</p>
 
-<h2 id="omawrite">Omawrite</h2>
+<h2 id="omawrite">Omawrite <a class="manual__heading-link" href="#omawrite" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/omacom-io/omawrite">Omawrite</a> is Omarchy’s own dead-simple Markdown writing app. No vaults, no plugins, just you and the words.</p>
 
 <p>You start Omawrite with <code>Super + Shift + W</code>.</p>
 
-<h2 id="pinta">Pinta</h2>
+<h2 id="pinta">Pinta <a class="manual__heading-link" href="#pinta" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.pinta-project.com/">Pinta</a> is a basic image editing tool that’s great for cropping, resizing, and other basic manipulations. Just don’t expect a Photoshop alternative. But it’s still got a Magic Wand and layers!</p>
 
 <p>You start Pinta via the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="aether">Aether</h2>
+<h2 id="aether">Aether <a class="manual__heading-link" href="#aether" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/bjarneo/aether">Aether</a> is a theming application that can extract colors from a background image and turn them into a complete, cohesive theme. It’s the easiest way to <a href="../making-your-own-theme/">make your own theme</a>.</p>
 
 <p>You start Aether via the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="localsend">LocalSend</h2>
+<h2 id="localsend">LocalSend <a class="manual__heading-link" href="#localsend" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://localsend.org/">LocalSend</a> lets you send files to other devices on the same network running the app, like Apple’s AirDrop. It’s cross-platform, though, so you can send files to and from Windows, macOS, Android, iOS, and of course Linux.</p>
 
@@ -167,43 +167,43 @@
 
 <p>Omarchy’s firewall is closed by default except for LocalSend’s port, so this works out of the box on a fresh install. See <a href="../security/">security</a>.</p>
 
-<h2 id="libreoffice">LibreOffice</h2>
+<h2 id="libreoffice">LibreOffice <a class="manual__heading-link" href="#libreoffice" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.libreoffice.org/">LibreOffice</a> is a complete office package with word processor, spreadsheet, presentations, drawing application, and more. It’s compatible with files from Microsoft Office, so this is a great way to be able to open those Word documents.</p>
 
 <p>You start LibreOffice via the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="omacalc">Omacalc</h2>
+<h2 id="omacalc">Omacalc <a class="manual__heading-link" href="#omacalc" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/omacom-io/omacalc">Omacalc</a> is Omarchy’s own dead-simple calculator, which opens in a floating window.</p>
 
 <p>You start Omacalc with <code>Super + Ctrl + Q</code> (or the calculator key, if your keyboard has one).</p>
 
-<h2 id="signal">Signal</h2>
+<h2 id="signal">Signal <a class="manual__heading-link" href="#signal" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://signal.org/">Signal</a> is the pioneer of E2E encrypted messaging, and a great communication option for anyone who’d prefer not to go through one of the big tech conglomerates.</p>
 
 <p>You start Signal with <code>Super + Shift + G</code>. It’s not part of the base install, so the first time you hit that, Omarchy will offer to install it for you (it’s also under <em>Install &gt; Service</em> in the Omarchy menu).</p>
 
-<h2 id="mpv">mpv</h2>
+<h2 id="mpv">mpv <a class="manual__heading-link" href="#mpv" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://mpv.io/">mpv</a> is a simple, fast media player that’ll play almost anything from any source. Great for watching videos.</p>
 
 <p>You start mpv via the application launcher (<code>Super + Space</code>) or just double-click on a video in the file manager.</p>
 
-<h2 id="obs-studio">OBS Studio</h2>
+<h2 id="obs-studio">OBS Studio <a class="manual__heading-link" href="#obs-studio" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://obsproject.com/">OBS Studio</a> lets you record or stream video from multiple inputs. You can mix a screencast with a webcam with a microphone input. It’s what was used to record the Omarchy screencasts.</p>
 
 <p>You start OBS Studio via the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="kdenlive">Kdenlive</h2>
+<h2 id="kdenlive">Kdenlive <a class="manual__heading-link" href="#kdenlive" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://kdenlive.org/">Kdenlive</a> is an excellent video editor. Perfect for working on video that comes out of OBS Studio before sharing it.</p>
 
 <p>You start Kdenlive via the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="omacut">Omacut</h2>
+<h2 id="omacut">Omacut <a class="manual__heading-link" href="#omacut" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/omacom-io/omacut">Omacut</a> is Omarchy’s own dead-simple video trimmer. When all you need is to cut the start and end off a clip, it beats firing up a full video editor.</p>
 

--- a/manual/hardware-authentication/index.html
+++ b/manual/hardware-authentication/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>Hardware authentication</h1>
-<h3 id="fingerprint-authentication">Fingerprint authentication</h3>
+<h3 id="fingerprint-authentication">Fingerprint authentication <a class="manual__heading-link" href="#fingerprint-authentication" aria-label="Link to this section">#</a></h3>
 
 <p>A lot of laptops come with a fingerprint sensor to do authentication. You can use this with Omarchy by running <em>Setup &gt; Security &gt; Fingerprint</em> in the Omarchy menu (<code>Super + Space</code>).</p>
 
@@ -122,7 +122,7 @@
 
 <p>You can remove the fingerprint authentication under <em>Remove &gt; Security &gt; Fingerprint</em> in the Omarchy menu.</p>
 
-<h3 id="fido2-authentication">Fido2 authentication</h3>
+<h3 id="fido2-authentication">Fido2 authentication <a class="manual__heading-link" href="#fido2-authentication" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re using a Fido2 device, you can set it up for <code>sudo</code> authentication using <em>Setup &gt; Security &gt; Fido2</em> in the Omarchy menu (<code>Super + Space</code>). It covers <code>sudo</code> and system authorization prompts, though, not unlocking your computer.</p>
 

--- a/manual/hotkeys/index.html
+++ b/manual/hotkeys/index.html
@@ -114,7 +114,7 @@
       <h1>Hotkeys</h1>
 <p>You can see all the main keyboard bindings with <code>Super + K</code> (Tmux bindings with <code>Super + Alt + K</code> and Herdr bindings with <code>Super + Ctrl + K</code>).</p>
 
-<h2 id="navigating">Navigating</h2>
+<h2 id="navigating">Navigating <a class="manual__heading-link" href="#navigating" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -331,7 +331,7 @@
   </tbody>
 </table>
 
-<h2 id="system-controls">System controls</h2>
+<h2 id="system-controls">System controls <a class="manual__heading-link" href="#system-controls" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -408,7 +408,7 @@
   </tbody>
 </table>
 
-<h2 id="adjustments">Adjustments</h2>
+<h2 id="adjustments">Adjustments <a class="manual__heading-link" href="#adjustments" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -453,7 +453,7 @@
   </tbody>
 </table>
 
-<h2 id="launching-apps">Launching apps</h2>
+<h2 id="launching-apps">Launching apps <a class="manual__heading-link" href="#launching-apps" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -576,7 +576,7 @@
 
 <p>Change/add bindings in <code>~/.config/hypr/bindings.lua</code>.</p>
 
-<h2 id="universal-clipboard">Universal clipboard</h2>
+<h2 id="universal-clipboard">Universal clipboard <a class="manual__heading-link" href="#universal-clipboard" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -607,7 +607,7 @@
 
 <p>Usually on Linux, you need <code>Ctrl + Shift + C/V</code> to copy’n’paste in the terminal and <code>Ctrl + C/V</code> to do it everywhere else. These Omarchy unified clipboard hotkeys work everywhere.</p>
 
-<h2 id="capture">Capture</h2>
+<h2 id="capture">Capture <a class="manual__heading-link" href="#capture" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -668,7 +668,7 @@
 
 <p>All capture options are also accessible under <em>Trigger &gt; Capture</em> in the Omarchy menu (<code>Super + Space</code>).</p>
 
-<h2 id="notifications">Notifications</h2>
+<h2 id="notifications">Notifications <a class="manual__heading-link" href="#notifications" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -701,7 +701,7 @@
   </tbody>
 </table>
 
-<h2 id="style">Style</h2>
+<h2 id="style">Style <a class="manual__heading-link" href="#style" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -734,7 +734,7 @@
 
 <p>All style options are also accessible under <em>Style</em> in the Omarchy menu (<code>Super + Space</code>).</p>
 
-<h2 id="toggles">Toggles</h2>
+<h2 id="toggles">Toggles <a class="manual__heading-link" href="#toggles" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -779,7 +779,7 @@
   </tbody>
 </table>
 
-<h2 id="reminders">Reminders</h2>
+<h2 id="reminders">Reminders <a class="manual__heading-link" href="#reminders" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -804,7 +804,7 @@
   </tbody>
 </table>
 
-<h2 id="notices">Notices</h2>
+<h2 id="notices">Notices <a class="manual__heading-link" href="#notices" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -829,11 +829,11 @@
   </tbody>
 </table>
 
-<h2 id="tmux">Tmux</h2>
+<h2 id="tmux">Tmux <a class="manual__heading-link" href="#tmux" aria-label="Link to this section">#</a></h2>
 
 <p>The prefix key is <code>Ctrl + Space</code> (<code>Ctrl + B</code> also works). You can change these bindings in <code>~/.config/tmux/tmux.conf</code>.</p>
 
-<h3 id="panes">Panes</h3>
+<h3 id="panes">Panes <a class="manual__heading-link" href="#panes" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -882,7 +882,7 @@
   </tbody>
 </table>
 
-<h3 id="windows">Windows</h3>
+<h3 id="windows">Windows <a class="manual__heading-link" href="#windows" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -919,7 +919,7 @@
   </tbody>
 </table>
 
-<h3 id="sessions">Sessions</h3>
+<h3 id="sessions">Sessions <a class="manual__heading-link" href="#sessions" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -964,7 +964,7 @@
   </tbody>
 </table>
 
-<h3 id="copy-mode-vi-style">Copy mode (vi-style)</h3>
+<h3 id="copy-mode-vi-style">Copy mode (vi-style) <a class="manual__heading-link" href="#copy-mode-vi-style" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -989,7 +989,7 @@
   </tbody>
 </table>
 
-<h3 id="general">General</h3>
+<h3 id="general">General <a class="manual__heading-link" href="#general" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -1014,7 +1014,7 @@
   </tbody>
 </table>
 
-<h3 id="tmux-layout-functions">Tmux layout functions</h3>
+<h3 id="tmux-layout-functions">Tmux layout functions <a class="manual__heading-link" href="#tmux-layout-functions" aria-label="Link to this section">#</a></h3>
 
 <p>These functions must be run inside a Tmux session.</p>
 
@@ -1041,7 +1041,7 @@
   </tbody>
 </table>
 
-<h2 id="ghostty-terminal">Ghostty Terminal</h2>
+<h2 id="ghostty-terminal">Ghostty Terminal <a class="manual__heading-link" href="#ghostty-terminal" aria-label="Link to this section">#</a></h2>
 
 <p>Ghostty terminal is installed using <em>Install &gt; Terminal</em> via the Omarchy menu.</p>
 
@@ -1096,7 +1096,7 @@
   </tbody>
 </table>
 
-<h2 id="file-manager">File Manager</h2>
+<h2 id="file-manager">File Manager <a class="manual__heading-link" href="#file-manager" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>
@@ -1121,9 +1121,9 @@
   </tbody>
 </table>
 
-<h2 id="neovim-w-lazyvim">Neovim (w/ lazyvim)</h2>
+<h2 id="neovim-w-lazyvim">Neovim (w/ lazyvim) <a class="manual__heading-link" href="#neovim-w-lazyvim" aria-label="Link to this section">#</a></h2>
 
-<h3 id="navigation">Navigation</h3>
+<h3 id="navigation">Navigation <a class="manual__heading-link" href="#navigation" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -1176,7 +1176,7 @@
   </tbody>
 </table>
 
-<h3 id="while-in-sidebar">While in sidebar</h3>
+<h3 id="while-in-sidebar">While in sidebar <a class="manual__heading-link" href="#while-in-sidebar" aria-label="Link to this section">#</a></h3>
 
 <table>
   <thead>
@@ -1215,7 +1215,7 @@
 
 <p><a href="https://www.lazyvim.org/keymaps">See all the Neovim hotkeys configured by LazyVim</a>.</p>
 
-<h2 id="quick-emojis">Quick Emojis</h2>
+<h2 id="quick-emojis">Quick Emojis <a class="manual__heading-link" href="#quick-emojis" aria-label="Link to this section">#</a></h2>
 
 <p>You can use <code>Super + Ctrl + E</code> to show a complete emoji picker that’ll put the selection on the clipboard or you can use these quick access options.</p>
 
@@ -1346,7 +1346,7 @@
   </tbody>
 </table>
 
-<h2 id="quick-completions">Quick Completions</h2>
+<h2 id="quick-completions">Quick Completions <a class="manual__heading-link" href="#quick-completions" aria-label="Link to this section">#</a></h2>
 
 <table>
   <thead>

--- a/manual/keyboard-mouse-trackpad/index.html
+++ b/manual/keyboard-mouse-trackpad/index.html
@@ -148,7 +148,7 @@ o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 
 <p>You can <a href="https://wiki.hypr.land/Configuring/Basics/Variables/#input">see all the input options</a> on the Hyprland wiki for inputs.</p>
 
-<p>By default, Omarchy uses CapsLock as the compose key for <a href="../hotkeys/#quick-emojis">quick emojis</a> and <a href="../hotkeys/#quick-completions">other completions</a>. If you’d rather keep CapsLock or use another key for compose sequences, change <code>compose:caps</code> in <code>kb_options</code>. For example, this moves the compose key to Right Alt:</p>
+<p>By default, Omarchy uses CapsLock as the compose key for <a href="../hotkeys/#quick-emojis">quick emojis</a> and <a href="../hotkeys/#quick-completions">other completions</a>. If you’d rather use CapsLock as Caps Lock, move the compose key elsewhere by changing <code>compose:caps</code> in <code>kb_options</code>. For example, this moves the compose key to Right Alt:</p>
 
 <pre><code class="language-lua">hl.config({
   input = {
@@ -157,7 +157,7 @@ o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 })
 </code></pre>
 
-<h3 id="trackpad-gestures">Trackpad gestures</h3>
+<h3 id="trackpad-gestures">Trackpad gestures <a class="manual__heading-link" href="#trackpad-gestures" aria-label="Link to this section">#</a></h3>
 
 <p>You can also turn on <a href="https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/">touchpad gestures</a>, like swiping with three fingers to change workspaces:</p>
 
@@ -166,11 +166,11 @@ o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 
 <p>On Dell XPS laptops with a haptic touchpad, you can also set the click strength to low, mid, or high under <em>Trigger &gt; Hardware &gt; Touchpad Haptics</em>.</p>
 
-<h3 id="typing-in-chinese-japanese-and-other-languages">Typing in Chinese, Japanese, and other languages</h3>
+<h3 id="typing-in-chinese-japanese-and-other-languages">Typing in Chinese, Japanese, and other languages <a class="manual__heading-link" href="#typing-in-chinese-japanese-and-other-languages" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy runs the <a href="https://fcitx-im.org/">fcitx5</a> input method framework as part of every session — it’s what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like <code>fcitx5-mozc</code> (Japanese) or <code>fcitx5-chinese-addons</code> (Chinese) with <code>omarchy pkg add</code>, plus <code>fcitx5-configtool</code> to add the engine to your input methods and set the key that switches between them.</p>
 
-<h3 id="use-alt-as-super">Use ALT as SUPER</h3>
+<h3 id="use-alt-as-super">Use ALT as SUPER <a class="manual__heading-link" href="#use-alt-as-super" aria-label="Link to this section">#</a></h3>
 
 <p>On some keyboards, it’s not convenient to use the primary meta key (Windows/cmd key) as SUPER. You can change this to be ALT instead using this change:</p>
 

--- a/manual/mac-support/index.html
+++ b/manual/mac-support/index.html
@@ -120,7 +120,7 @@
 
 <p><img src="/manual/images/macbook-omarchy.webp" alt="macbook-omarchy" /></p>
 
-<h3 id="installing-omarchy-on-mac">Installing Omarchy on Mac</h3>
+<h3 id="installing-omarchy-on-mac">Installing Omarchy on Mac <a class="manual__heading-link" href="#installing-omarchy-on-mac" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy only supports being the <strong>only</strong> OS installed at the moment. During the installation, the drive will be wiped and MacOS will no longer be bootable.</p>
 
@@ -128,7 +128,7 @@
 
 <p>For the sake of this part, we’ll assume you’ve already reviewed <a href="../getting-started/">Getting Started</a> and have your USB drive ready. If you don’t go ahead and do that now.</p>
 
-<h4 id="disable-secure-boot">Disable Secure Boot</h4>
+<h4 id="disable-secure-boot">Disable Secure Boot <a class="manual__heading-link" href="#disable-secure-boot" aria-label="Link to this section">#</a></h4>
 
 <p>It is necessary to disable Apple’s Secure Boot in order to boot the bootable USB, as well as the OS. To disable it, perform the following:</p>
 
@@ -142,7 +142,7 @@
   <li>Choose “Allow booting from external or removable media” from the External Boot options</li>
 </ol>
 
-<h4 id="start-the-installation">Start the Installation</h4>
+<h4 id="start-the-installation">Start the Installation <a class="manual__heading-link" href="#start-the-installation" aria-label="Link to this section">#</a></h4>
 
 <ol>
   <li>Insert the USB drive</li>
@@ -153,11 +153,11 @@
 
 <p>The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.</p>
 
-<h3 id="known-limitations">Known Limitations</h3>
+<h3 id="known-limitations">Known Limitations <a class="manual__heading-link" href="#known-limitations" aria-label="Link to this section">#</a></h3>
 
 <p>Members of the community are constantly working on solutions to these challenges so if these are problematic for you, join #omarchy-on-other in our <a href="https://discord.gg/tXFUdasqhY">Discord</a> and see if there’s any up-to-date methods for resolving these.</p>
 
-<h4 id="devices-with-t1-chip">Devices with T1 Chip</h4>
+<h4 id="devices-with-t1-chip">Devices with T1 Chip <a class="manual__heading-link" href="#devices-with-t1-chip" aria-label="Link to this section">#</a></h4>
 
 <p>The Apple T1 chip was introduced in late 2016 and used exclusively in the first-generation MacBook Pro models with Touch Bar.</p>
 <ul>
@@ -166,14 +166,14 @@
   <li>MacBook Pro 15-inch (2016) – Model: A1707</li>
 </ul>
 
-<h4 id="known-issues">Known Issues</h4>
+<h4 id="known-issues">Known Issues <a class="manual__heading-link" href="#known-issues" aria-label="Link to this section">#</a></h4>
 
 <ul>
   <li>Touch Bar is non-functional</li>
   <li>Sound is not functioning</li>
 </ul>
 
-<h4 id="devices-with-t2-chip">Devices with T2 Chip</h4>
+<h4 id="devices-with-t2-chip">Devices with T2 Chip <a class="manual__heading-link" href="#devices-with-t2-chip" aria-label="Link to this section">#</a></h4>
 
 <p>The Apple T2 Security Chip was introduced in 2017. The T2 chip was discontinued with the transition to Apple silicon (M-series chips) starting in 2020.</p>
 

--- a/manual/making-your-own-theme/index.html
+++ b/manual/making-your-own-theme/index.html
@@ -118,25 +118,25 @@
 
 <p>You can also use the included Aether application to create a new theme using a lovely GUI interface to play with colors and search for backgrounds. Just start it via the apps menu on <code>Super + Alt + Space</code>.</p>
 
-<h3 id="light-mode">Light mode</h3>
+<h3 id="light-mode">Light mode <a class="manual__heading-link" href="#light-mode" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re making a light mode theme, set <code>mode = "light"</code> at the top of your <code>colors.toml</code>. Then it’ll automatically be paired with light mode for all the apps. (The old way of dropping an empty file called <code>light.mode</code> in the root of your theme still works too.)</p>
 
-<h3 id="icon-colors">Icon colors</h3>
+<h3 id="icon-colors">Icon colors <a class="manual__heading-link" href="#icon-colors" aria-label="Link to this section">#</a></h3>
 
 <p>If you’d like to color-match the file manager icons to your theme, add a file called <code>icons.theme</code> with the name of the icon set you want to use. By default, the options are: <code>Yaru Yaru-blue Yaru-dark Yaru-magenta Yaru-olive Yaru-prussiangreen Yaru-purple Yaru-red Yaru-sage Yaru-wartybrown Yaru-yellow</code>.</p>
 
-<h3 id="unlock-image">Unlock image</h3>
+<h3 id="unlock-image">Unlock image <a class="manual__heading-link" href="#unlock-image" aria-label="Link to this section">#</a></h3>
 
 <p>Themes supplied with <code>unlock.png</code> and <code>preview-unlock.png</code> images will be listed under <em>Style &gt; Unlock</em>. Your <code>unlock.png</code> should preferably be a transparent png. And you can create the preview image using <code>omarchy plymouth preview</code>.</p>
 
-<h3 id="theming-apps-omarchy-doesnt-cover">Theming apps Omarchy doesn’t cover</h3>
+<h3 id="theming-apps-omarchy-doesnt-cover">Theming apps Omarchy doesn’t cover <a class="manual__heading-link" href="#theming-apps-omarchy-doesnt-cover" aria-label="Link to this section">#</a></h3>
 
 <p>If you use an app that isn’t in that list, you can teach Omarchy to theme it yourself with a template. Drop a file in <code>~/.config/omarchy/themed/</code> named after the config it generates plus a <code>.tpl</code> extension, and write the config with <code>{{ background }}</code>, <code>{{ foreground }}</code>, <code>{{ accent }}</code>, <code>{{ red }}</code>, <code>{{ color0 }}</code> through <code>{{ color15 }}</code>, and the rest of the palette as placeholders. Every time you switch themes, the file is regenerated with that theme’s colors.</p>
 
 <p>There’s a fully commented <code>alacritty.toml.tpl.sample</code> in that folder to copy from — it lists every variable you can use, plus the <code>_strip</code> and <code>_rgb</code> modifiers for apps that want their colors without the <code>#</code> or as decimal RGB. Your templates take priority over Omarchy’s own, so you can also use this to override how a built-in app gets themed.</p>
 
-<h3 id="distributing-your-theme">Distributing your theme</h3>
+<h3 id="distributing-your-theme">Distributing your theme <a class="manual__heading-link" href="#distributing-your-theme" aria-label="Link to this section">#</a></h3>
 
 <p>If you want to distribute your theme so others can use it, you need to put it on a public git server, like GitHub. Then people can install it using <em>Install &gt; Style &gt; Theme</em> in the Omarchy menu using that URL. It’s recommended that you follow the naming convention of <code>omarchy-[themename]-theme</code>, as the theme will show correctly as just <code>[themename]</code> in the theme selection menu after installation.</p>
 

--- a/manual/monitors/index.html
+++ b/manual/monitors/index.html
@@ -130,7 +130,7 @@ local omarchy_monitor_scale = 1
 
 <p>You can also quickly step through the major monitor scaling ratios (1x, 1.25x, 1.6x, 2x, 3x, 4x) using <code>Super + /</code> to go higher and <code>Super + Alt + /</code> to go lower. If you have the default configuration, these changes will also persist past reboot.</p>
 
-<h3 id="making-text-bigger-or-smaller">Making text bigger or smaller</h3>
+<h3 id="making-text-bigger-or-smaller">Making text bigger or smaller <a class="manual__heading-link" href="#making-text-bigger-or-smaller" aria-label="Link to this section">#</a></h3>
 
 <p>Monitor scaling changes the size of everything. If all you want is bigger or smaller <em>text</em>, there’s a single knob for that:</p>
 
@@ -139,23 +139,23 @@ local omarchy_monitor_scale = 1
 
 <p>That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Run it without an argument to see where you’re at, and <code>omarchy display text size reset</code> to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.</p>
 
-<h3 id="extending-and-mirroring-laptop-displays">Extending and mirroring laptop displays</h3>
+<h3 id="extending-and-mirroring-laptop-displays">Extending and mirroring laptop displays <a class="manual__heading-link" href="#extending-and-mirroring-laptop-displays" aria-label="Link to this section">#</a></h3>
 
 <p>When you connect an external screen to your laptop, the display is automatically extended. But you can change that to mirroring instead using <em>Trigger &gt; Hardware</em> in the Omarchy menu or <code>Super + Ctrl + Alt + Delete</code>. This is especially helpful if that external screen is a projector, and you want to show something while working.</p>
 
 <p>When you’re extending, closing the lid on the laptop will automatically turn off the internal screen. Opening the lid will turn it back on. You can also control this manually using <em>Trigger &gt; Hardware</em> in the Omarchy menu or <code>Super + Ctrl + Delete</code>.</p>
 
-<h3 id="arranging-multiple-screens">Arranging multiple screens</h3>
+<h3 id="arranging-multiple-screens">Arranging multiple screens <a class="manual__heading-link" href="#arranging-multiple-screens" aria-label="Link to this section">#</a></h3>
 
 <p>Hyprland works great with multiple screens. Read more about how to lay them out in <a href="https://wiki.hypr.land/Configuring/Basics/Monitors/">the Hyprland monitor documentation</a>. You can <a href="https://wiki.hypr.land/Configuring/Basics/Workspace-Rules/">bind specific workspaces to specific monitors</a> as well. In Omarchy, these rules go in <code>~/.config/hypr/monitors.lua</code> as <code>hl.monitor</code> entries — the file ships with commented examples for pinning a specific monitor to a resolution, position, and rotation.</p>
 
 <p>You can also checkout <a href="https://github.com/erans/hyprmon/">Hyprmon</a>, if you’d like a TUI to help you with the positioning of multiple screens.</p>
 
-<h3 id="controlling-brightness">Controlling brightness</h3>
+<h3 id="controlling-brightness">Controlling brightness <a class="manual__heading-link" href="#controlling-brightness" aria-label="Link to this section">#</a></h3>
 
 <p>Monitor brightness is controlled by the dedicated function keys for brightness up/down. If you hold down shift while pressing these, you’ll go to maximum or minimum brightness. The keys control the display you’re focused on, so external monitors that speak DDC/CI are adjusted the same way as the laptop screen.</p>
 
-<h3 id="apple-displays">Apple Displays</h3>
+<h3 id="apple-displays">Apple Displays <a class="manual__heading-link" href="#apple-displays" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re using an Apple display, the regular keyboard brightness keys will also automatically work, if you’re focused on the Apple display. This is done through the <code>asdcontrol</code> command.</p>
 

--- a/manual/navigation/index.html
+++ b/manual/navigation/index.html
@@ -138,7 +138,7 @@
 
 <p>You can also go full screen with <code>Super + F</code> or even just full-width (keeping the top bar) with <code>Super + Alt + F</code> or full-screen within a window with <code>Super + Ctrl + F</code> (good for YouTube!).</p>
 
-<h3 id="dwindle-vs-scrolling-layout">Dwindle vs scrolling layout</h3>
+<h3 id="dwindle-vs-scrolling-layout">Dwindle vs scrolling layout <a class="manual__heading-link" href="#dwindle-vs-scrolling-layout" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy’s default layout is called dwindle. It keeps all the windows you open on a single workspace visible at all time, even if it has to shrink them down.</p>
 
@@ -159,25 +159,25 @@
 })
 </code></pre>
 
-<h3 id="grouping-windows">Grouping windows</h3>
+<h3 id="grouping-windows">Grouping windows <a class="manual__heading-link" href="#grouping-windows" aria-label="Link to this section">#</a></h3>
 
 <p>Windows can be grouped using <code>Super + G</code>. Once you’re in a group, every window you start while that’s active will belong to the group. You can move between these grouped windows using <code>Super + Ctrl + Arrow Left/Right</code> or <code>Super + Alt + 1/2/3/4</code> to go directly to grouped window in order.</p>
 
 <p>You can move a window out of the grouping with <code>Super + Alt + G</code> or disassemble the entire group by hitting <code>Super + G</code> again. Finally, you can move windows outside the group into it with <code>Super + Alt + Arrows</code>.</p>
 
-<h3 id="popping-windows">Popping windows</h3>
+<h3 id="popping-windows">Popping windows <a class="manual__heading-link" href="#popping-windows" aria-label="Link to this section">#</a></h3>
 
 <p>You can pop a window out of its workspace allocation with <code>Super + O</code>. That’ll pin it as a floating window that follows you on whatever workspace you go to. Great for video players and the like.</p>
 
 <p><img src="/manual/images/navigation-popped-window.webp" alt="navigation-popped-window" /></p>
 
-<h3 id="scratchpad-workspace">Scratchpad workspace</h3>
+<h3 id="scratchpad-workspace">Scratchpad workspace <a class="manual__heading-link" href="#scratchpad-workspace" aria-label="Link to this section">#</a></h3>
 
 <p>Finally, there’s a special scratchpad workspace that overlays on whatever workspace you’re currently on. You access what’s on that using <code>Super + S</code> and you place windows there using <code>Super + Alt + S</code>.</p>
 
 <p>It works well for controls or perhaps a terminal that you quickly want to interact with in an overlay without leaving the current workspace. If you want to move a window off the scratchpad, you just move it directly to another workspace with something like <code>Super + Shift + 1</code> to move it to workspace 1.</p>
 
-<h3 id="it-takes-some-getting-used-to">It takes some getting used to!</h3>
+<h3 id="it-takes-some-getting-used-to">It takes some getting used to! <a class="manual__heading-link" href="#it-takes-some-getting-used-to" aria-label="Link to this section">#</a></h3>
 
 <p>It takes a little while to get used to navigating your desktop like this, but once you do, it’ll be hard to go back to a traditional mouse-driven desktop experience!</p>
 

--- a/manual/neovim/index.html
+++ b/manual/neovim/index.html
@@ -120,7 +120,7 @@
 
 <p>But Omarchy ships with a complete Neovim setup — the <code>omarchy-nvim</code> package — that’s been lovingly tuned to showcase the best of what’s possible out of the box. Without you having to write a single line of configuration! It’s built on <a href="https://www.lazyvim.org/">LazyVim</a>, a distribution of Neovim plugins and configurations. It’s awesome.</p>
 
-<h2 id="lazyvim-basics">LazyVim Basics</h2>
+<h2 id="lazyvim-basics">LazyVim Basics <a class="manual__heading-link" href="#lazyvim-basics" aria-label="Link to this section">#</a></h2>
 
 <p>As mentioned, I’m not going to teach you vim in this short introduction, but I can show you a few basics of LazyVim, and how to get around.</p>
 
@@ -147,11 +147,11 @@
 
 <p>You can see all the possible commands on <a href="https://www.lazyvim.org/keymaps">the LazyVim Keymaps page</a>.</p>
 
-<h2 id="starting-neovim">Starting Neovim</h2>
+<h2 id="starting-neovim">Starting Neovim <a class="manual__heading-link" href="#starting-neovim" aria-label="Link to this section">#</a></h2>
 
 <p>You can start Neovim using <code>Super + Shift + N</code> (the binding launches your default editor, which is Neovim out of the box), but it’s usually easier to drive it from the terminal by navigating to the directory you wish to work in and typing <code>n</code>. The <code>n</code> is the alias for <code>nvim</code>, which will use the the present directory to open by default. You can open a single file with <code>n myfile.txt</code>.</p>
 
-<h2 id="using-neovim-for-sudo-edits">Using Neovim for sudo edits</h2>
+<h2 id="using-neovim-for-sudo-edits">Using Neovim for sudo edits <a class="manual__heading-link" href="#using-neovim-for-sudo-edits" aria-label="Link to this section">#</a></h2>
 
 <p>If you need to edit files that you can only change as a super user, you can use neovim with all your plugins setup by running <code>sudoedit /etc/sudoers.d/00-sudo-only-file</code>.</p>
 

--- a/manual/networking/index.html
+++ b/manual/networking/index.html
@@ -116,35 +116,35 @@
 
 <p>That panel scans for Wi-Fi networks, shows signal strength, and connects. Ethernet needs nothing at all — plug it in and it works. If you’d rather stay in the terminal, <code>nmtui</code> gives you the same controls, and there’s an <code>omarchy network</code> command group too.</p>
 
-<h2 id="sharing-your-wi-fi">Sharing your Wi-Fi</h2>
+<h2 id="sharing-your-wi-fi">Sharing your Wi-Fi <a class="manual__heading-link" href="#sharing-your-wi-fi" aria-label="Link to this section">#</a></h2>
 
 <p>Rather than reading a long password out loud, run <em>Setup &gt; Network &gt; QR Code</em> while you’re on Wi-Fi. That puts a QR code on screen that any phone camera can scan to join. It’s one of those things you’ll use more than you’d expect once you know it’s there.</p>
 
 <p>If you actually need the password itself, <code>omarchy network password &lt;interface&gt;</code> prints it.</p>
 
-<h2 id="dns">DNS</h2>
+<h2 id="dns">DNS <a class="manual__heading-link" href="#dns" aria-label="Link to this section">#</a></h2>
 
 <p>Omarchy uses whatever DNS your network hands out over DHCP. You can override that for the whole machine under <em>Setup &gt; Network &gt; DNS</em>, where Cloudflare and Google are one click away. Pick <em>Custom</em> to type in your own servers.</p>
 
 <p>From the terminal, <code>omarchy dns</code> prints the current provider and <code>omarchy dns Cloudflare</code> sets one.</p>
 
-<h2 id="pinning-the-wi-fi-band">Pinning the Wi-Fi band</h2>
+<h2 id="pinning-the-wi-fi-band">Pinning the Wi-Fi band <a class="manual__heading-link" href="#pinning-the-wi-fi-band" aria-label="Link to this section">#</a></h2>
 
 <p>If your router puts 2.4GHz, 5GHz, and 6GHz on the same network name, your laptop will sometimes cling to the slow one. <code>omarchy network band</code> shows which band you’re on, and <code>omarchy network band 5</code> pins it. Use <code>auto</code> to let it choose again.</p>
 
 <p>This pins the band rather than a specific access point, so you keep roaming between APs normally.</p>
 
-<h2 id="how-fast-is-it">How fast is it?</h2>
+<h2 id="how-fast-is-it">How fast is it? <a class="manual__heading-link" href="#how-fast-is-it" aria-label="Link to this section">#</a></h2>
 
 <p><em>Trigger &gt; Speed Test &gt; Network Speed Test</em> measures your actual up and down speed with a pair of dials. From the terminal it’s <code>omarchy network speedtest down</code> or <code>up</code>. (There’s a disk speed test sitting next to it in that menu, if you’re benchmarking the other bottleneck.)</p>
 
-<h2 id="the-firewall">The firewall</h2>
+<h2 id="the-firewall">The firewall <a class="manual__heading-link" href="#the-firewall" aria-label="Link to this section">#</a></h2>
 
 <p>The firewall is on by default and blocks all incoming traffic, with one exception: port 53317, so <a href="../guis/">LocalSend</a> works out of the box.</p>
 
 <p>SSH is off until you turn it on with <em>Setup &gt; Security &gt; SSHD</em>, which starts the daemon, opens port 22 rate-limited against brute force, and authorizes a key. Docker is locked down too, so containers can’t accidentally expose themselves to the world. See <a href="../security/">security</a> for the whole story.</p>
 
-<h2 id="tailscale">Tailscale</h2>
+<h2 id="tailscale">Tailscale <a class="manual__heading-link" href="#tailscale" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://tailscale.com/">Tailscale</a> is a mesh VPN that makes reaching all your computers and servers over the internet simple and secure. Install it with <em>Install &gt; Service &gt; Tailscale</em>.</p>
 
@@ -152,7 +152,7 @@
 
 <p>Installing it also adds a web app for the Tailscale admin console.</p>
 
-<h2 id="when-it-stops-working">When it stops working</h2>
+<h2 id="when-it-stops-working">When it stops working <a class="manual__heading-link" href="#when-it-stops-working" aria-label="Link to this section">#</a></h2>
 
 <p>Before rebooting, try restarting the offending piece on its own. <em>Update &gt; Hardware</em> has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up most “it worked five minutes ago” situations. See <a href="../troubleshooting/">troubleshooting</a>.</p>
 

--- a/manual/notices/index.html
+++ b/manual/notices/index.html
@@ -114,13 +114,13 @@
       <h1>Notices</h1>
 <p>You can quickly access the date and time, battery status, and current weather using the hotkey notices.</p>
 
-<h3 id="date--time">Date &amp; Time</h3>
+<h3 id="date--time">Date &amp; Time <a class="manual__heading-link" href="#date--time" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + Alt + T</code></p>
 
 <p><img src="/manual/images/notice-datetime.webp" alt="notice-datetime" /></p>
 
-<h3 id="weather">Weather</h3>
+<h3 id="weather">Weather <a class="manual__heading-link" href="#weather" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + Alt + W</code></p>
 
@@ -128,7 +128,7 @@
 
 <p>The location is detected from your IP address, which is usually close enough, but not always. You can pin it down with <code>omarchy weather location --set Malibu</code>, or be exact about it by adding coordinates: <code>omarchy weather location --set Malibu 34.0259,-118.7798</code>. Run <code>omarchy weather location</code> on its own to see where it thinks you are, and <code>--clear</code> to go back to auto-detection.</p>
 
-<h3 id="battery">Battery</h3>
+<h3 id="battery">Battery <a class="manual__heading-link" href="#battery" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + Alt + B</code></p>
 

--- a/manual/omarchy-cli/index.html
+++ b/manual/omarchy-cli/index.html
@@ -167,7 +167,7 @@ Capture commands — Screenshots and screen recording:
 
 <p>Every command takes <code>--help</code> too, whether you ask a whole group (<code>omarchy capture --help</code>) or a single command (<code>omarchy capture screenshot --help</code>).</p>
 
-<h3 id="opening-the-menu-from-the-terminal">Opening the menu from the terminal</h3>
+<h3 id="opening-the-menu-from-the-terminal">Opening the menu from the terminal <a class="manual__heading-link" href="#opening-the-menu-from-the-terminal" aria-label="Link to this section">#</a></h3>
 
 <p>The Omarchy menu is scriptable as well, which is handy for your own keybindings. <code>omarchy menu</code> opens it at the root, and you can jump straight to any point in the tree by naming it: <code>omarchy menu summon style.theme</code> goes right to the theme picker, <code>omarchy menu toggle system</code> opens the system menu and closes it again if it’s already up, and <code>omarchy menu close</code> puts it away.</p>
 

--- a/manual/omarchy-on/index.html
+++ b/manual/omarchy-on/index.html
@@ -112,31 +112,31 @@
 
     <article class="manual__content">
       <h1>Omarchy on...</h1>
-<h3 id="apple-m1m2-chips">Apple M1/M2 chips</h3>
+<h3 id="apple-m1m2-chips">Apple M1/M2 chips <a class="manual__heading-link" href="#apple-m1m2-chips" aria-label="Link to this section">#</a></h3>
 
 <p><a href="https://asahi-alarm.org/">Asahi Alarm</a> is a version of Arch for Apple M1/M2 computers built on top of <a href="https://asahilinux.org/">Asahi Linux</a>. You can get Omarchy running on top of that with some effort. See <a href="https://codeberg.org/malik-na/omarchy-mac">the user-driven guide</a>.</p>
 
-<h3 id="apple-virtual-machine">Apple Virtual Machine</h3>
+<h3 id="apple-virtual-machine">Apple Virtual Machine <a class="manual__heading-link" href="#apple-virtual-machine" aria-label="Link to this section">#</a></h3>
 
 <p>You can also install Omarchy inside a Parallels VM. Quite the cumbersome process, but there’s <a href="https://github.com/basecamp/omarchy/discussions/452">a user-driven guide</a> for that too.</p>
 
-<h3 id="virtualbox">VirtualBox</h3>
+<h3 id="virtualbox">VirtualBox <a class="manual__heading-link" href="#virtualbox" aria-label="Link to this section">#</a></h3>
 
 <p>VirtualBox is a popular VM runner. <a href="https://github.com/basecamp/omarchy/discussions/176">You can run Omarchy inside that too</a>. But performance probably won’t be great.</p>
 
-<h3 id="vmware-workstation-on-windows-11">VMware Workstation on Windows 11</h3>
+<h3 id="vmware-workstation-on-windows-11">VMware Workstation on Windows 11 <a class="manual__heading-link" href="#vmware-workstation-on-windows-11" aria-label="Link to this section">#</a></h3>
 
 <p>Another popular VM runner for Windows. <a href="https://github.com/basecamp/omarchy/discussions/572">Omarchy has been setup inside of that as well</a>.</p>
 
-<h3 id="steam-deck">Steam Deck</h3>
+<h3 id="steam-deck">Steam Deck <a class="manual__heading-link" href="#steam-deck" aria-label="Link to this section">#</a></h3>
 
 <p>The Steam Deck runs on Arch, which means you can run Omarchy on your Steam Deck. Altynbek Orumbayev has <a href="https://github.com/aorumbayev/deckarchy">a full setup script and explanation on how to do it</a>. How cool is that!</p>
 
-<h3 id="nixos">NixOS</h3>
+<h3 id="nixos">NixOS <a class="manual__heading-link" href="#nixos" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy is really Arch + Hyprland, but Henry Sipp has <a href="https://github.com/henrysipp/omarchy-nix">ported the essence of the setup to NixOS</a>. So if you’ve been nix-pilled, here’s a good starting point. It may or may not stay up-to-date with the latest Omarchy changes, but it’s pretty cool none the less!</p>
 
-<h3 id="something-else">Something else!</h3>
+<h3 id="something-else">Something else! <a class="manual__heading-link" href="#something-else" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re trying to get Omarchy running on a configuration that isn’t the default, you should join the #omarchy-on-other channel on <a href="https://discord.gg/tXFUdasqhY">our community Discord</a>.</p>
 

--- a/manual/screenshots-recording/index.html
+++ b/manual/screenshots-recording/index.html
@@ -149,7 +149,7 @@
   </tbody>
 </table>
 
-<h2 id="screenshots">Screenshots</h2>
+<h2 id="screenshots">Screenshots <a class="manual__heading-link" href="#screenshots" aria-label="Link to this section">#</a></h2>
 
 <p>Hit <code>Print Screen</code> and the screen freezes so nothing shifts under you while you aim. Drag a box for a freeform region, or just click once and the shot snaps to whatever rectangle you clicked in — a window if you landed on one, the whole monitor if you landed on the bar or in a gap. Changed your mind? Hit <code>Print Screen</code> again to dismiss the picker.</p>
 
@@ -159,7 +159,7 @@
 
 <p>From the terminal, <code>omarchy screenshot</code> takes the same shot, and you can be explicit about it: <code>omarchy capture screenshot region</code> for freeform only, <code>windows</code> to snap to window and monitor rectangles, or <code>fullscreen</code> to skip the picker entirely and grab the focused monitor. A second argument of <code>copy</code> puts the shot only on the clipboard, and <code>save</code> only on disk.</p>
 
-<h3 id="driving-the-picker-from-the-keyboard">Driving the picker from the keyboard</h3>
+<h3 id="driving-the-picker-from-the-keyboard">Driving the picker from the keyboard <a class="manual__heading-link" href="#driving-the-picker-from-the-keyboard" aria-label="Link to this section">#</a></h3>
 
 <p>While the selection is up, you don’t have to use the mouse at all:</p>
 
@@ -192,7 +192,7 @@
 
 <p>The arrows and Tab move the cursor to the window they pick, so the highlight follows along and you can see what you’re about to capture. These bindings only exist while a selection is on screen, so they can’t collide with anything in your own config.</p>
 
-<h2 id="screen-recording">Screen recording</h2>
+<h2 id="screen-recording">Screen recording <a class="manual__heading-link" href="#screen-recording" aria-label="Link to this section">#</a></h2>
 
 <p><code>Alt + Print Screen</code> opens <em>Trigger &gt; Capture &gt; Screenrecord</em>, which asks what you want on the soundtrack: no audio, desktop audio, desktop plus microphone, or desktop plus microphone plus webcam. That last one only shows up if you actually have a camera plugged in. Pick one and you get the same picker as a screenshot: drag a region, or click a window or monitor.</p>
 
@@ -202,7 +202,7 @@
 
 <p>Stopping does a bit of tidying before it hands you the file: the first frame gets trimmed, and if there’s audio it’s normalized to -14 LUFS with the PipeWire capture pop at the very start muted out. Then a notification appears with a thumbnail from the recording. Click it to play the file in mpv.</p>
 
-<h3 id="the-webcam-overlay">The webcam overlay</h3>
+<h3 id="the-webcam-overlay">The webcam overlay <a class="manual__heading-link" href="#the-webcam-overlay" aria-label="Link to this section">#</a></h3>
 
 <p>When you record with a webcam, the camera appears as a pinned, cropped portrait window in the bottom-right corner of whatever you’re recording. If it’s sitting on top of something you need, resize it on the fly:</p>
 
@@ -229,7 +229,7 @@
 
 <p>You can also call it directly with <code>omarchy-capture-webcam-resize small</code>, or <code>reset</code> to go back to medium.</p>
 
-<h2 id="text-qr-codes-and-colours">Text, QR codes, and colours</h2>
+<h2 id="text-qr-codes-and-colours">Text, QR codes, and colours <a class="manual__heading-link" href="#text-qr-codes-and-colours" aria-label="Link to this section">#</a></h2>
 
 <p><code>Super + Ctrl + Print Screen</code> selects a region and OCRs it to the clipboard. That’s covered properly in <a href="../text-extraction-dictation/">Text Extraction &amp; Dictation</a>.</p>
 
@@ -237,7 +237,7 @@
 
 <p><code>Super + Print Screen</code> (or <em>Trigger &gt; Capture &gt; Color</em>) turns the cursor into an eyedropper. Click anything on screen and the colour lands on the clipboard. Press the hotkey again to back out without picking.</p>
 
-<h2 id="transcoding-before-you-share">Transcoding before you share</h2>
+<h2 id="transcoding-before-you-share">Transcoding before you share <a class="manual__heading-link" href="#transcoding-before-you-share" aria-label="Link to this section">#</a></h2>
 
 <p>A 4K screen recording or a raw HEIC off your phone is often too big to just send. <code>Super + Ctrl + .</code> (or <em>Trigger &gt; Transcode</em>) fixes that. It offers you a fuzzy file picker over <code>~/Pictures</code> and <code>~/Videos</code>, then asks for a format and a size.</p>
 
@@ -245,7 +245,7 @@
 
 <p>It works from the terminal too, if you already know what you want: <code>omarchy transcode ~/Videos/demo.mov mp4 1080p</code>. There’s also <code>omarchy transcode ascii</code>, which turns an image into ASCII art — that one’s mostly for <a href="../branding/">branding</a>.</p>
 
-<h2 id="sending-it-somewhere">Sending it somewhere</h2>
+<h2 id="sending-it-somewhere">Sending it somewhere <a class="manual__heading-link" href="#sending-it-somewhere" aria-label="Link to this section">#</a></h2>
 
 <p>Once you’ve got the file, <code>Super + Ctrl + S</code> opens the Share menu and sends it to another device on your network via LocalSend. See <a href="../guis/">GUIs</a> for that.</p>
 

--- a/manual/security/index.html
+++ b/manual/security/index.html
@@ -122,23 +122,23 @@
   <li><em>Cloudflare protects us from DDoS</em>: All the Omarchy distribution infrastructure — the ISOs, the Omarchy packages, the Arch mirror — is protected behind Cloudflare’s formidable DDoS shield and hosted on their CDN. This provides superb availability.</li>
 </ol>
 
-<h2 id="changing-your-passwords">Changing your passwords</h2>
+<h2 id="changing-your-passwords">Changing your passwords <a class="manual__heading-link" href="#changing-your-passwords" aria-label="Link to this section">#</a></h2>
 
 <p>You have two passwords on an encrypted install: the one that unlocks the drive at boot, and the one you log in and <code>sudo</code> with. Both can be changed under <em>Update &gt; Password</em> in the Omarchy menu — <em>Drive Encryption</em> for the first, <em>User</em> for the second. Changing the drive password asks for the current one first, so have it handy.</p>
 
-<h2 id="passing-on-a-machine-youve-already-used">Passing on a machine you’ve already used</h2>
+<h2 id="passing-on-a-machine-youve-already-used">Passing on a machine you’ve already used <a class="manual__heading-link" href="#passing-on-a-machine-youve-already-used" aria-label="Link to this section">#</a></h2>
 
 <p>If you’re handing your machine over to someone else, you don’t have to reinstall it. Run <em>Setup &gt; Reset Computer</em> in the Omarchy menu, type <code>reset</code> to confirm, and reboot. That wipes every user account and everything in <code>/home</code>, throws away all the packages and system changes you made since installation, and clears the machine’s identity — network connections, host keys, and all. What comes back up is the setup wizard from the first boot, ready for its new owner to enter their own name, password, and encryption password.</p>
 
 <p>It works by restoring the baseline snapshot the installer takes, so it’s only available on machines installed from the Omarchy ISO. And on a drive without encryption, a reset is deletion rather than a secure erase, so if the data was sensitive, do a fresh install instead.</p>
 
-<h2 id="passwordless-sudo">Passwordless sudo</h2>
+<h2 id="passwordless-sudo">Passwordless sudo <a class="manual__heading-link" href="#passwordless-sudo" aria-label="Link to this section">#</a></h2>
 
 <p>Sometimes you want <code>sudo</code> to stop asking, most often when an AI agent is doing a long stretch of system work for you. <em>Setup &gt; Security &gt; Passwordless Sudo</em> turns that off for 15 minutes and then puts it back automatically. Run it again before the timer runs out to end it early, and pass your own number of minutes with <code>omarchy-sudo-passwordless 30</code> if 15 isn’t enough.</p>
 
 <p>Be clear-eyed about this one: while it’s on, anything running as your user can do anything as root without being asked. That’s the whole point, and it’s also the whole risk.</p>
 
-<h2 id="signing-keys">Signing Keys</h2>
+<h2 id="signing-keys">Signing Keys <a class="manual__heading-link" href="#signing-keys" aria-label="Link to this section">#</a></h2>
 
 <p>The public key for all ISO signatures and Omarchy repo package is <code>40DFB630FF42BCFFB047046CF0134EE680CAC571</code> (<a href="https://keys.openpgp.org/search?q=pkgs%40omarchy.org">verify at openpgp.org</a>). The <code>omarchy/omarchy-keyring</code> package contains this as well and will be used to rollout any potential updates seamlessly.</p>
 

--- a/manual/shell-functions/index.html
+++ b/manual/shell-functions/index.html
@@ -114,21 +114,21 @@
       <h1>Shell Functions</h1>
 <p>Omarchy comes with a set of shell functions to simplify common tasks and encapsulate convoluted parameter calls.</p>
 
-<h2 id="compression">Compression</h2>
+<h2 id="compression">Compression <a class="manual__heading-link" href="#compression" aria-label="Link to this section">#</a></h2>
 
 <ul>
   <li><code>compress [file/dir]</code>: Create a tar.gz archive from the file/dir.</li>
   <li><code>decompress [file.tar.gz]</code>: Expand a tar.gz file.</li>
 </ul>
 
-<h2 id="drives">Drives</h2>
+<h2 id="drives">Drives <a class="manual__heading-link" href="#drives" aria-label="Link to this section">#</a></h2>
 
 <ul>
   <li><code>iso2sd [image.iso]</code>: Create a bootable drive on an SD card using the referenced iso file and picking the drive interactively.</li>
   <li><code>format-drive [device] [name]</code>: Format an entire disk with a single exFAT partition (which works on Windows and macOS too). Run it without arguments to see the available drives. Be careful!</li>
 </ul>
 
-<h2 id="dev-layouts">Dev layouts</h2>
+<h2 id="dev-layouts">Dev layouts <a class="manual__heading-link" href="#dev-layouts" aria-label="Link to this section">#</a></h2>
 
 <p>Instant multi-pane development layouts for tmux:</p>
 
@@ -141,14 +141,14 @@
 
 <p>The same layouts are available for Herdr as <code>hdl</code>, <code>hds</code>, <code>hdlm</code>, and <code>hsl</code>.</p>
 
-<h2 id="git-worktrees">Git worktrees</h2>
+<h2 id="git-worktrees">Git worktrees <a class="manual__heading-link" href="#git-worktrees" aria-label="Link to this section">#</a></h2>
 
 <ul>
   <li><code>ga [branch]</code>: Create a new worktree and branch next to the current repository and jump into it.</li>
   <li><code>gd</code>: Remove the current worktree and its branch (asks for confirmation first).</li>
 </ul>
 
-<h2 id="rsync-watchers">Rsync watchers</h2>
+<h2 id="rsync-watchers">Rsync watchers <a class="manual__heading-link" href="#rsync-watchers" aria-label="Link to this section">#</a></h2>
 
 <ul>
   <li><code>rsw [source] [destination]</code>: Start a background watcher that rsyncs source to destination whenever anything changes. The destination can be a remote host, like <code>rsw ~/Work/app nyc-dev:Work/app</code>.</li>
@@ -156,7 +156,7 @@
   <li><code>dsw</code>: Stop all active watchers.</li>
 </ul>
 
-<h2 id="ssh-portforwarding">SSH Portforwarding</h2>
+<h2 id="ssh-portforwarding">SSH Portforwarding <a class="manual__heading-link" href="#ssh-portforwarding" aria-label="Link to this section">#</a></h2>
 
 <p>Ideal for doing web development with localhost secure-context privileges against a remote box.</p>
 
@@ -168,7 +168,7 @@
 
 <p>Say you start a dev server on port <code>3000</code> on a machine accessible as <code>nyc-dev</code>, then you can run <code>fip nyc-dev 3000</code> to forward that port, so <code>localhost:3000</code> actually reaches <code>nyc-dev:3000</code>, but without the need for SSL certificates to establish the secure context needed for testing web sockets or the like.</p>
 
-<h2 id="ssh-reconnection">SSH reconnection</h2>
+<h2 id="ssh-reconnection">SSH reconnection <a class="manual__heading-link" href="#ssh-reconnection" aria-label="Link to this section">#</a></h2>
 
 <p><code>ssh</code> itself is wrapped in a function that cleans up the terminal if a connection dies while a remote tmux, Herdr, or editor has claimed it, and then automatically reconnects when an interactive session drops (Ctrl-C stops the retry loop).</p>
 

--- a/manual/shell-plugins/index.html
+++ b/manual/shell-plugins/index.html
@@ -118,7 +118,7 @@
 
 <p>The first-party plugins ship with Omarchy and live in <code>$OMARCHY_PATH/shell/plugins/</code>. Anything you add yourself — your own experiments, or something you found on GitHub — lives in <code>~/.config/omarchy/plugins/</code>. Both are discovered the same way at startup; the only difference is where they sit on disk.</p>
 
-<h2 id="seeing-what-you-have">Seeing what you have</h2>
+<h2 id="seeing-what-you-have">Seeing what you have <a class="manual__heading-link" href="#seeing-what-you-have" aria-label="Link to this section">#</a></h2>
 
 <pre><code>omarchy plugin list
 </code></pre>
@@ -127,7 +127,7 @@
 
 <p>Plugin ids are namespaced. The built-ins all start with <code>omarchy.</code> — <code>omarchy.clock</code>, <code>omarchy.network</code>, <code>omarchy.notifications</code> — and that namespace is reserved, so a third-party plugin can never claim it.</p>
 
-<h2 id="turning-them-on-and-off">Turning them on and off</h2>
+<h2 id="turning-them-on-and-off">Turning them on and off <a class="manual__heading-link" href="#turning-them-on-and-off" aria-label="Link to this section">#</a></h2>
 
 <pre><code>omarchy plugin enable omarchy.tailscale
 omarchy plugin disable omarchy.weather
@@ -139,7 +139,7 @@ omarchy plugin disable omarchy.weather
 
 <p>A full bar plugin has no off state at all. There’s always exactly one bar, so you replace it by enabling another one. Bar widget placement is covered in <a href="../the-top-bar/">the top bar</a>.</p>
 
-<h2 id="adding-a-plugin-from-git">Adding a plugin from git</h2>
+<h2 id="adding-a-plugin-from-git">Adding a plugin from git <a class="manual__heading-link" href="#adding-a-plugin-from-git" aria-label="Link to this section">#</a></h2>
 
 <p>A third-party plugin is just a git repo with a <code>manifest.json</code> at its root.</p>
 
@@ -163,7 +163,7 @@ omarchy plugin update
 
 <p>Removal disables the plugin first, then deletes it if it’s a git checkout (the repo is still upstream) or unlinks it if it’s a symlink. A hand-made plugin folder with no git repo gets moved to a timestamped backup inside the plugins directory instead of being deleted outright.</p>
 
-<h2 id="cloning-a-built-in-to-modify-it">Cloning a built-in to modify it</h2>
+<h2 id="cloning-a-built-in-to-modify-it">Cloning a built-in to modify it <a class="manual__heading-link" href="#cloning-a-built-in-to-modify-it" aria-label="Link to this section">#</a></h2>
 
 <p>This is my favorite part. If you want to change how a built-in widget behaves, don’t edit the files under <code>$OMARCHY_PATH</code> — those belong to the package and the next update will overwrite them. Clone it instead:</p>
 
@@ -176,7 +176,7 @@ omarchy plugin update
 
 <p>Saving a file anywhere under <code>~/.config/omarchy/plugins/</code> reloads the plugin code automatically, so you can leave the editor open and watch your changes land.</p>
 
-<h2 id="writing-your-own">Writing your own</h2>
+<h2 id="writing-your-own">Writing your own <a class="manual__heading-link" href="#writing-your-own" aria-label="Link to this section">#</a></h2>
 
 <p>A plugin is a directory with a <code>manifest.json</code> and some QML. The manifest declares <code>schemaVersion: 1</code>, an <code>id</code>, <code>name</code>, <code>version</code>, one or more <code>kinds</code>, and an <code>entryPoints</code> object pointing at the QML file for each kind:</p>
 
@@ -226,7 +226,7 @@ omarchy plugin update
 
 <p>For the full picture, the source is the documentation: <code>shell/README.md</code> in the Omarchy repo covers the manifest schema, the shell’s IPC contract, and the exact shape of <code>shell.json</code>, and <code>shell/plugins/README.md</code> lists every first-party plugin with its id, kinds, and entry points.</p>
 
-<h2 id="sharing-yours-with-the-world">Sharing yours with the world</h2>
+<h2 id="sharing-yours-with-the-world">Sharing yours with the world <a class="manual__heading-link" href="#sharing-yours-with-the-world" aria-label="Link to this section">#</a></h2>
 
 <p>Once you’ve made something you like, put it in a public git repo. That’s the whole distribution mechanism — anyone can then run <code>omarchy plugin add</code> against your URL and have it running in seconds.</p>
 

--- a/manual/shell-tools/index.html
+++ b/manual/shell-tools/index.html
@@ -114,7 +114,7 @@
       <h1>Shell Tools</h1>
 <p>In addition to the standard Linux tools, Omarchy also ships with a bunch of enhanced shell tools. Here are the key ones.</p>
 
-<h2 id="fzf">fzf</h2>
+<h2 id="fzf">fzf <a class="manual__heading-link" href="#fzf" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://junegunn.github.io/fzf/">fzf</a> gives you fuzzy finding of files via the <code>ff</code> alias. Go to any directory, type <code>ff</code>, and you’ll be able to fuzzy find your way to any file in that tree, while seeing a preview of the files you’re narrowing down on the right-hand side.</p>
 
@@ -124,13 +124,13 @@
 
 <p>The full manual can be found via <code>man fzf</code>.</p>
 
-<h2 id="zoxide">Zoxide</h2>
+<h2 id="zoxide">Zoxide <a class="manual__heading-link" href="#zoxide" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/ajeetdsouza/zoxide">Zoxide</a> is a replacement for cd. It remembers the directories you’ve been in, so you can more easily jump to them next time. Say you do <code>cd ~/.config/omarchy</code> once. Next time, you can just do <code>cd omarchy</code> (or even just <code>cd oma</code>), and Zoxide will take you directly there.</p>
 
 <p>The full manual can be found via <code>man zoxide</code>.</p>
 
-<h2 id="ripgrep">ripgrep</h2>
+<h2 id="ripgrep">ripgrep <a class="manual__heading-link" href="#ripgrep" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/BurntSushi/ripgrep">ripgrep</a> searches the contents of files by using <code>rg &lt;pattern&gt; &lt;path&gt;</code>, like <code>rg Controller app/</code> to find all mentions of <code>Controller</code> in the directory app.</p>
 
@@ -138,35 +138,35 @@
 
 <p>The full manual can be found via <code>man rg</code>.</p>
 
-<h2 id="eza">eza</h2>
+<h2 id="eza">eza <a class="manual__heading-link" href="#eza" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://eza.rocks/">eza</a> is a replacement for ls. It gives you directory listings with more information, color, and icons. By default, eza has been aliased as ls. You can also use <code>lt</code> to get a listing of two-deep levels of nesting. <code>lsa</code> gives you a listing including hidden files. And <code>lta</code> a nested listing with hidden files.</p>
 
 <p>The full manual can be found via <code>man eza</code>.</p>
 
-<h2 id="fd">fd</h2>
+<h2 id="fd">fd <a class="manual__heading-link" href="#fd" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/sharkdp/fd">fd</a> is an easier to use replacement for <code>find</code>. Use <code>fd person.rb</code> to find a file called <code>person.rb</code> within the current tree. <code>fd person.rb /</code> will search the entire file system. <code>fd person.rb / -H</code> searches the entire file system, including hidden directories.</p>
 
 <p>The full manual can be found via <code>man fd</code>.</p>
 
-<h2 id="bat">bat</h2>
+<h2 id="bat">bat <a class="manual__heading-link" href="#bat" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/sharkdp/bat">bat</a> is <code>cat</code> with syntax highlighting, line numbers, and paging. Run <code>bat somefile.rb</code> and you’ll see why it’s hard to go back. It’s also quietly doing work for you elsewhere: it’s what colors your man pages, and what renders the previews in <code>ff</code>.</p>
 
 <p>The full manual can be found via <code>man bat</code>.</p>
 
-<h2 id="tldr">tldr</h2>
+<h2 id="tldr">tldr <a class="manual__heading-link" href="#tldr" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://tldr.sh/">tldr</a> is the antidote to man pages that open with three screens of history before showing you a single example. <code>tldr tar</code> gives you the handful of invocations you actually wanted.</p>
 
-<h2 id="yt-dlp">yt-dlp</h2>
+<h2 id="yt-dlp">yt-dlp <a class="manual__heading-link" href="#yt-dlp" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/yt-dlp/yt-dlp">yt-dlp</a> downloads video from YouTube and hundreds of other sites. <code>yt-dlp &lt;url&gt;</code> grabs the best quality available into the current directory.</p>
 
 <p>The full manual can be found via <code>man yt-dlp</code>.</p>
 
-<h2 id="try">try</h2>
+<h2 id="try">try <a class="manual__heading-link" href="#try" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/tobi/try">try</a> makes it easy to manage programming experiments with date-stamped directories. All experiments live in <code>~/Work/tries</code> and you can access them via <code>try</code>.</p>
 

--- a/manual/system-sleep/index.html
+++ b/manual/system-sleep/index.html
@@ -114,17 +114,17 @@
       <h1>System sleep</h1>
 <p>Omarchy enables suspend and hibernation by default, but if you’re having issues with either on your machine, you can toggle them off.</p>
 
-<h3 id="power-profiles">Power profiles</h3>
+<h3 id="power-profiles">Power profiles <a class="manual__heading-link" href="#power-profiles" aria-label="Link to this section">#</a></h3>
 
 <p>On a laptop, Omarchy remembers your power profile separately for plugged in and running on battery, and switches between the two as you plug and unplug. Out of the box that means performance on AC and balanced on battery.</p>
 
 <p>You can see what your machine offers with <code>omarchy powerprofiles list</code>, and set the one you want for the state you’re currently in with <code>omarchy powerprofiles set autodetect power-saver</code>. To set the other state without unplugging anything, name it directly: <code>omarchy powerprofiles set battery power-saver</code>. Whatever you pick is what you’ll get back the next time you’re in that state.</p>
 
-<h3 id="toggle-suspend">Toggle suspend</h3>
+<h3 id="toggle-suspend">Toggle suspend <a class="manual__heading-link" href="#toggle-suspend" aria-label="Link to this section">#</a></h3>
 
 <p>You toggle suspend by running <code>omarchy toggle suspend</code> from the terminal. That just reveals/hides the option under <em>System</em> (or <code>Super + Esc</code>), and then you can see if it works consistently on your system. If not, you can hide it again with the same command.</p>
 
-<h3 id="toggle-hibernation">Toggle hibernation</h3>
+<h3 id="toggle-hibernation">Toggle hibernation <a class="manual__heading-link" href="#toggle-hibernation" aria-label="Link to this section">#</a></h3>
 
 <p>You set up hibernation by running <code>omarchy hibernation setup</code> from the terminal. Hibernation creates a /swap subvolume on your boot drive the size of your physical RAM allocation, so make sure you have plenty of room to spare. On a 32GB machine, you’ll always need 32GB+ free for this volume. Hibernation also requires the default Limine bootloader.</p>
 

--- a/manual/system-snapshots/index.html
+++ b/manual/system-snapshots/index.html
@@ -130,7 +130,7 @@
 
 <p><em>Note: This feature is only available on installations using the Limine boot loader, which has been the default since Omarchy 2.0. It’s not available if you’re on GRUB or systemd-boot.</em></p>
 
-<h3 id="skipping-the-boot-menu">Skipping the boot menu</h3>
+<h3 id="skipping-the-boot-menu">Skipping the boot menu <a class="manual__heading-link" href="#skipping-the-boot-menu" aria-label="Link to this section">#</a></h3>
 
 <p>If you never touch the boot menu and just want the machine to go straight to the decryption screen, run <em>Setup &gt; Direct Boot</em> in the Omarchy menu. That adds an EFI entry pointing directly at Omarchy, so the firmware boots it without stopping at Limine.</p>
 

--- a/manual/terminal/index.html
+++ b/manual/terminal/index.html
@@ -118,7 +118,7 @@
 
 <p>You start a new terminal using <code>Super + Return</code>. (This binding will automatically point to whichever Terminal you’ve installed via <em>Install &gt; Terminal</em>, and you can switch between installed terminals under <em>Setup &gt; Defaults &gt; Terminal</em>.)</p>
 
-<h2 id="tmux">Tmux</h2>
+<h2 id="tmux">Tmux <a class="manual__heading-link" href="#tmux" aria-label="Link to this section">#</a></h2>
 
 <p>Tmux provides a consistent, programmable interface for panes, windows (aka tabs), and resumable sessions regardless of your terminal. It even works on remote hosts, so when you’re SSH’ing into a server, you can use the same approach.</p>
 
@@ -126,7 +126,7 @@
 
 <p>Omarchy ships with an ergonomically-optimized Tmux configuration, which has a lot of keybindings to learn, so keep <a href="../hotkeys/#tmux">the cheatsheet handy</a>.</p>
 
-<h2 id="tmux-layout-functions">Tmux layout functions</h2>
+<h2 id="tmux-layout-functions">Tmux layout functions <a class="manual__heading-link" href="#tmux-layout-functions" aria-label="Link to this section">#</a></h2>
 
 <p>Because Tmux is programmable, we can use functions to create layouts. Omarchy ships with four different functions for common developer layouts.</p>
 

--- a/manual/text-extraction-dictation/index.html
+++ b/manual/text-extraction-dictation/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>Text Extraction &amp; Dictation</h1>
-<h3 id="text-extraction">Text Extraction</h3>
+<h3 id="text-extraction">Text Extraction <a class="manual__heading-link" href="#text-extraction" aria-label="Link to this section">#</a></h3>
 
 <p>Hit <code>Super + Ctrl + PrtScr</code> to select a region on the screen for text extraction. The tesseract open source OCR model will then quickly convert that selection into text and place it on the clipboard. Then you just hit <code>Super + V</code> to paste.</p>
 
@@ -120,7 +120,7 @@
 
 <p><img src="/manual/images/text-extraction.webp" alt="text-extraction" /></p>
 
-<h3 id="dictation">Dictation</h3>
+<h3 id="dictation">Dictation <a class="manual__heading-link" href="#dictation" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy offers AI dictation via <a href="https://voxtype.io/">Voxtype</a>. You install it via <em>Install &gt; AI &gt; Dictation</em> through the Omarchy menu. By default, it’ll load a base English model that takes up 150MB. But you can tweak which model you’d like to use by running <code>voxtype setup model</code> in the terminal. And you can tweak all the settings via <code>~/.config/voxtype/config.toml</code>.</p>
 

--- a/manual/the-top-bar/index.html
+++ b/manual/the-top-bar/index.html
@@ -116,13 +116,13 @@
 
 <p>It’s also the one piece of the desktop that’s always on screen, so it’s worth knowing what all those little glyphs do.</p>
 
-<h2 id="whats-on-it-by-default">What’s on it by default</h2>
+<h2 id="whats-on-it-by-default">What’s on it by default <a class="manual__heading-link" href="#whats-on-it-by-default" aria-label="Link to this section">#</a></h2>
 
 <p>The bar has three sections. On the left sits the Omarchy logo (the menu launcher) and the workspace indicators. In the center you get the status indicators, the clock, the keyboard layout, the weather, and an Omarchy update badge. On the right: the system tray, agents, bluetooth, network, audio, display, and power.</p>
 
 <p>A few of those only show up when they have something to say. The keyboard layout appears only if you’ve configured more than one layout. The update badge appears only when there’s an Omarchy update waiting. And the agents icon appears the first time Omarchy finds AI coding usage on the machine (see <a href="../ai/">AI</a>).</p>
 
-<h2 id="clicking-around">Clicking around</h2>
+<h2 id="clicking-around">Clicking around <a class="manual__heading-link" href="#clicking-around" aria-label="Link to this section">#</a></h2>
 
 <p>Nearly every widget does something on left, right, and middle click, and several respond to scrolling. This is the part people miss — the right and middle buttons are where a lot of the good stuff hides.</p>
 
@@ -225,7 +225,7 @@
 
 <p>Not everything in that table is on your bar out of the box. The media widget (MPRIS now-playing, with a scrolling track and artist) and the microphone widget are both built in but off by default — add them if you want them, as described below.</p>
 
-<h2 id="the-panels">The panels</h2>
+<h2 id="the-panels">The panels <a class="manual__heading-link" href="#the-panels" aria-label="Link to this section">#</a></h2>
 
 <p>Clicking a bar icon opens a panel, which is a proper popup with sliders, lists, and keyboard navigation rather than a tooltip. Each one also has a hotkey, so you never have to aim at a 16-pixel glyph:</p>
 
@@ -283,7 +283,7 @@
 
 <p><code>Super + Ctrl + 1-9</code> counts panels left to right in the right section, skipping the tray since it has no panel of its own. So the number matches the icon you’d point at.</p>
 
-<h3 id="tailscale-and-dropbox">Tailscale and Dropbox</h3>
+<h3 id="tailscale-and-dropbox">Tailscale and Dropbox <a class="manual__heading-link" href="#tailscale-and-dropbox" aria-label="Link to this section">#</a></h3>
 
 <p>Two more widgets appear on the bar only once you install the matching service from <strong>Install → Service</strong>, and both are worth knowing about because they do more than report status.</p>
 
@@ -293,13 +293,13 @@
 
 <p>Removing either service takes its widget back off the bar.</p>
 
-<h2 id="indicators">Indicators</h2>
+<h2 id="indicators">Indicators <a class="manual__heading-link" href="#indicators" aria-label="Link to this section">#</a></h2>
 
 <p>The little cluster in the center is the indicators widget. These are status glyphs for modes you’ve turned on: do not disturb, night light, a queued <a href="../reminders/">reminder</a>, an active screen recording, stay awake, and <a href="../text-extraction-dictation/">dictation</a>. They light up when the mode is active and otherwise stay out of the way — hover the center of the bar to peek at the inactive ones. Clicking an indicator toggles that mode.</p>
 
 <p>If you’d rather they were always visible, set <code>alwaysShow</code> to <code>true</code> on the widget. And if you only care about some of them, list the ones you want in <code>items</code>: <code>["Dnd", "Reminder", "NightLight"]</code>. You can have more than one indicators widget, so different sections can show different subsets.</p>
 
-<h2 id="rearranging-the-bar">Rearranging the bar</h2>
+<h2 id="rearranging-the-bar">Rearranging the bar <a class="manual__heading-link" href="#rearranging-the-bar" aria-label="Link to this section">#</a></h2>
 
 <p>The bar configures itself. You don’t have to open a config file to move things.</p>
 
@@ -322,11 +322,11 @@ omarchy bar defaults          # back to the shipped layout
 omarchy plugin disable omarchy.weather
 </code></pre>
 
-<h2 id="hiding-the-bar">Hiding the bar</h2>
+<h2 id="hiding-the-bar">Hiding the bar <a class="manual__heading-link" href="#hiding-the-bar" aria-label="Link to this section">#</a></h2>
 
 <p><code>Super + Shift + Space</code> toggles the bar off and back on without killing the shell — panels and hotkeys keep working, you just get the pixels back. It’s also in the menu under <strong>Trigger → Toggle → Menu Bar</strong>.</p>
 
-<h2 id="the-config-file">The config file</h2>
+<h2 id="the-config-file">The config file <a class="manual__heading-link" href="#the-config-file" aria-label="Link to this section">#</a></h2>
 
 <p>All of it is stored in <code>~/.config/omarchy/shell.json</code>, under the <code>bar</code> key. Here’s a trimmed version:</p>
 

--- a/manual/themes/index.html
+++ b/manual/themes/index.html
@@ -177,7 +177,7 @@
 <p><img src="/manual/images/white-preview.webp" alt="white" />
 <em>White</em></p>
 
-<h3 id="unlocks">Unlocks</h3>
+<h3 id="unlocks">Unlocks <a class="manual__heading-link" href="#unlocks" aria-label="Link to this section">#</a></h3>
 
 <p>Themes can also have a custom unlock design, which is used for the boot decryption process. You can select one of these under <em>Style &gt; Unlock</em>. They look like this:</p>
 

--- a/manual/toggles-idle-screensaver/index.html
+++ b/manual/toggles-idle-screensaver/index.html
@@ -114,7 +114,7 @@
       <h1>Toggles, Idle &amp; the Screensaver</h1>
 <p>A lot of what you change day to day isn’t really a setting. It’s a mode you flip on for an hour and off again: night light while you’re working late, do not disturb while you’re presenting, stay awake while you’re watching something. Omarchy calls those toggles, and they all work the same way — a hotkey, a menu entry, and a command, all hitting the same switch.</p>
 
-<h3 id="the-toggle-menu">The toggle menu</h3>
+<h3 id="the-toggle-menu">The toggle menu <a class="manual__heading-link" href="#the-toggle-menu" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + O</code> opens <em>Trigger &gt; Toggle</em> directly, or you can walk there from the Omarchy menu (<code>Super + Space</code>). Everything in that list is a switch you can flip without thinking about where the state lives.</p>
 
@@ -193,13 +193,13 @@
 
 <p>The flags are named for the off state — <code>screensaver-off</code>, <code>suspend-off</code>, <code>bar-off</code> — so their presence means the feature is disabled.</p>
 
-<h3 id="indicators-in-the-bar">Indicators in the bar</h3>
+<h3 id="indicators-in-the-bar">Indicators in the bar <a class="manual__heading-link" href="#indicators-in-the-bar" aria-label="Link to this section">#</a></h3>
 
 <p>When a mode is on, you get a small glyph in the middle of the top bar next to the clock. That’s the indicators widget, and it carries dictation, screen recording, pending reminders, night light, do not disturb, and stay awake.</p>
 
 <p>Inactive indicators are hidden. Hover the area around them and they fade in dimmed, so you can click one to turn it on without knowing its hotkey. Clicking an active one turns it back off. If you’d rather see all of them all the time, set <code>alwaysShow</code> to <code>true</code> on the <code>omarchy.indicators</code> entry in <code>~/.config/omarchy/shell.json</code> — see <a href="../the-top-bar/">the top bar</a> for how bar widgets are configured.</p>
 
-<h3 id="night-light">Night light</h3>
+<h3 id="night-light">Night light <a class="manual__heading-link" href="#night-light" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + N</code> warms the screen to 4000K, and hitting it again puts it back to 6500K. It’s driven by hyprsunset, which the toggle starts for you if it isn’t already running.</p>
 
@@ -213,7 +213,7 @@
 
 <p>Then start hyprsunset at login by adding <code>o.launch_on_start("hyprsunset")</code> to <code>~/.config/hypr/autostart.lua</code>. The 4000K/6500K pair used by the toggle is fixed, so the config file is where you go if you want a different temperature.</p>
 
-<h3 id="do-not-disturb">Do not disturb</h3>
+<h3 id="do-not-disturb">Do not disturb <a class="manual__heading-link" href="#do-not-disturb" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + ,</code> silences notifications. No toasts pop up while it’s on, and the crossed-out bell indicator sits in the bar to remind you why the desktop has gone quiet.</p>
 
@@ -221,7 +221,7 @@
 
 <p>Two kinds of message still get through: Omarchy’s own confirmation toasts for something you just did (“Theme changed”, “Screenshot saved”), and critical alerts sent from the command line. Chat apps that mark everything critical to force their way in front of you don’t qualify.</p>
 
-<h3 id="idle">Idle</h3>
+<h3 id="idle">Idle <a class="manual__heading-link" href="#idle" aria-label="Link to this section">#</a></h3>
 
 <p>The Omarchy shell owns idle behavior, and the timings are a top-level <code>idle</code> block in <code>~/.config/omarchy/shell.json</code>:</p>
 
@@ -242,7 +242,7 @@
 
 <p>This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in <a href="../system-sleep/">system sleep</a>.</p>
 
-<h3 id="the-screensaver">The screensaver</h3>
+<h3 id="the-screensaver">The screensaver <a class="manual__heading-link" href="#the-screensaver" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy’s screensaver is ASCII art running through random text effects, one instance per monitor. Any key or mouse movement exits it.</p>
 
@@ -252,7 +252,7 @@
 
 <p>The logo it draws is yours to change, under <em>Style &gt; Screensaver</em>. Upload a png or svg and Omarchy converts it to ASCII. See <a href="../branding/">branding</a>.</p>
 
-<h3 id="the-lock-screen">The lock screen</h3>
+<h3 id="the-lock-screen">The lock screen <a class="manual__heading-link" href="#the-lock-screen" aria-label="Link to this section">#</a></h3>
 
 <p><code>Super + Ctrl + L</code> locks the machine. That runs the lock screen from the Omarchy shell, blanks the display, resets your keyboard layout to the first one so you’re not typing your password in the wrong alphabet, and — if you have it running — locks 1Password on the way out.</p>
 

--- a/manual/troubleshooting/index.html
+++ b/manual/troubleshooting/index.html
@@ -112,17 +112,17 @@
 
     <article class="manual__content">
       <h1>Troubleshooting</h1>
-<h3 id="i-broke-my-system-with-an-update">I broke my system with an update!</h3>
+<h3 id="i-broke-my-system-with-an-update">I broke my system with an update! <a class="manual__heading-link" href="#i-broke-my-system-with-an-update" aria-label="Link to this section">#</a></h3>
 
 <p>First try to <a href="../system-snapshots/">rollback your system</a> the version before your recent update. If that doesn’t work, use <code>omarchy-debug</code> to share with your problem on #omarchy-help in the Discord. And if all that fails, you can reinstall the defaults configs and packages using <code>omarchy-reinstall</code>.</p>
 
-<h3 id="why-are-some-apps-so-large-on-my-display">Why are some apps so large on my display?</h3>
+<h3 id="why-are-some-apps-so-large-on-my-display">Why are some apps so large on my display? <a class="manual__heading-link" href="#why-are-some-apps-so-large-on-my-display" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy assumes a 2x high-resolution display, which requires setting <code>GDK_SCALE</code> to 2 in <code>~/.config/hypr/monitors.lua</code>. But if you’re on a 1x display, you can change <code>local omarchy_gdk_scale = 2</code> to 1 (and then restart any app that’s oversized). See <a href="../monitors/">the manual on monitors</a>.</p>
 
 <p>For Spotify, you can use <code>Ctrl + Minus</code> to shrink the UI (and <code>Ctrl + Plus</code> to make it bigger).</p>
 
-<h3 id="why-isnt-caps-lock-working">Why isn’t Caps Lock working?</h3>
+<h3 id="why-isnt-caps-lock-working">Why isn’t Caps Lock working? <a class="manual__heading-link" href="#why-isnt-caps-lock-working" aria-label="Link to this section">#</a></h3>
 
 <p>In Omarchy, Caps Lock has been designated to be the xcompose key. That’s how you get <a href="../hotkeys/#quick-emojis">quick emojis</a> and <a href="../hotkeys/#quick-completions">other autocompletions</a> done. If you really miss using Caps Lock, you can remap the xcompose key to something else by editing <code>~/.config/hypr/input.lua</code>, like setting it to the right alt key:</p>
 
@@ -133,23 +133,23 @@
 })
 </code></pre>
 
-<h3 id="my-wi-fi-bluetooth-audio-or-trackpad-just-stopped-working">My Wi-Fi, Bluetooth, audio, or trackpad just stopped working</h3>
+<h3 id="my-wi-fi-bluetooth-audio-or-trackpad-just-stopped-working">My Wi-Fi, Bluetooth, audio, or trackpad just stopped working <a class="manual__heading-link" href="#my-wi-fi-bluetooth-audio-or-trackpad-just-stopped-working" aria-label="Link to this section">#</a></h3>
 
 <p>Before you reboot, try restarting the offending subsystem on its own. <em>Update &gt; Hardware</em> in the Omarchy menu has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up the majority of “it worked five minutes ago” situations — a Bluetooth headset that won’t reconnect, a trackpad that went dead after a suspend, sound that vanished when you unplugged a monitor.</p>
 
-<h3 id="why-are-my-external-speakers-not-playing">Why are my external speakers not playing?</h3>
+<h3 id="why-are-my-external-speakers-not-playing">Why are my external speakers not playing? <a class="manual__heading-link" href="#why-are-my-external-speakers-not-playing" aria-label="Link to this section">#</a></h3>
 
 <p>Probably because they’re not set as the primary output. Click on the speaker icon on the right side of the bar, and it’ll open the volume popup where you can pick the output device (and mix per-app volumes too).</p>
 
-<h3 id="my-laptop-speakers-sound-off">My laptop speakers sound off</h3>
+<h3 id="my-laptop-speakers-sound-off">My laptop speakers sound off <a class="manual__heading-link" href="#my-laptop-speakers-sound-off" aria-label="Link to this section">#</a></h3>
 
 <p>On some laptops, Omarchy automatically applies a speaker tuning that corrects the built-in speakers’ frequency response. <code>omarchy audio tuning status</code> tells you whether one is active on your machine, and <code>omarchy audio tuning off</code> turns it off if you’d rather hear the speakers raw.</p>
 
-<h3 id="why-cant-i-login-or-sudo-with-my-password">Why can’t I login or sudo with my password?</h3>
+<h3 id="why-cant-i-login-or-sudo-with-my-password">Why can’t I login or sudo with my password? <a class="manual__heading-link" href="#why-cant-i-login-or-sudo-with-my-password" aria-label="Link to this section">#</a></h3>
 
 <p>You probably typed it wrong too many times and got locked out. If this is happening on the lock screen, you can hit <code>CTRL + ALT + F2</code> to start a new TTY where you can login as root, then run <code>faillock --reset --user [your-username]</code>. That’ll reset the lockout, and you’re good to go.</p>
 
-<h3 id="why-isnt-my-1password-authorization-prompts-for-1password-ssh-agent--cli-appearing">Why isn’t my 1Password authorization prompts for 1Password SSH Agent / CLI appearing?</h3>
+<h3 id="why-isnt-my-1password-authorization-prompts-for-1password-ssh-agent--cli-appearing">Why isn’t my 1Password authorization prompts for 1Password SSH Agent / CLI appearing? <a class="manual__heading-link" href="#why-isnt-my-1password-authorization-prompts-for-1password-ssh-agent--cli-appearing" aria-label="Link to this section">#</a></h3>
 
 <p>This can happen for 2 reasons:</p>
 

--- a/manual/tuis/index.html
+++ b/manual/tuis/index.html
@@ -112,7 +112,7 @@
 
     <article class="manual__content">
       <h1>TUIs</h1>
-<h2 id="lazygit">Lazygit</h2>
+<h2 id="lazygit">Lazygit <a class="manual__heading-link" href="#lazygit" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/jesseduffield/lazygit">Lazygit</a> is a delightful alternative to something like the GitHub Desktop application, and it runs inside the terminal.</p>
 
@@ -120,7 +120,7 @@
 
 <p>You hop between the different panes using <code>Tab</code>. In the Files pane, you select files for staging using <code>Space</code>, and then you can create a new commit using <code>c</code>. You can see all the commands available using <code>?</code>.</p>
 
-<h2 id="lazydocker">Lazydocker</h2>
+<h2 id="lazydocker">Lazydocker <a class="manual__heading-link" href="#lazydocker" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/jesseduffield/lazydocker">Lazydocker</a> is made in the same spirit like Lazygit, and also gives you a terminal interface for managing your containers and images.</p>
 
@@ -128,37 +128,37 @@
 
 <p>You stop a container using <code>s</code> or start/restart it using <code>r</code>. See all commands using <code>?</code>.</p>
 
-<h2 id="btop">Btop</h2>
+<h2 id="btop">Btop <a class="manual__heading-link" href="#btop" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/aristocratos/btop">Btop</a> is a beautiful resource manager that shows memory, CPU, disk, and network usage. It also lists all active processes, and allows you to manage them.</p>
 
 <p>Omarchy calls it Activity, and you start it by hitting <code>Super + Ctrl + T</code>. It opens as a floating window, which you can tile with <code>Super + T</code>.</p>
 
-<h2 id="herdr">Herdr</h2>
+<h2 id="herdr">Herdr <a class="manual__heading-link" href="#herdr" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/omacom-io/herdr">Herdr</a> is a terminal workspace manager that gives you workspaces, tabs, and panes, and keeps them all running in a persistent session you can detach from and come back to later.</p>
 
 <p>You start it (or reattach to your existing session) with <code>Super + Ctrl + Return</code>. Omarchy ships a Herdr configuration that mirrors its Tmux config, so the prefix key is <code>Ctrl + Space</code> here too. You can browse all the keybindings with <code>Super + Ctrl + K</code>.</p>
 
-<h2 id="fastfetch">Fastfetch</h2>
+<h2 id="fastfetch">Fastfetch <a class="manual__heading-link" href="#fastfetch" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://github.com/fastfetch-cli/fastfetch">Fastfetch</a> shows system information, like kernel version, uptime, theme, CPU, memory, and more. It’s a successor to the popular neofetch tool.</p>
 
 <p>Omarchy has packaged this as <em>About</em> in the Omarchy menu (<code>Super + Space</code>).</p>
 
-<h2 id="disk-usage">Disk Usage</h2>
+<h2 id="disk-usage">Disk Usage <a class="manual__heading-link" href="#disk-usage" aria-label="Link to this section">#</a></h2>
 
 <p>When the drive fills up and you have no idea what’s eating it, launch <em>Disk Usage</em> from the app launcher (<code>Super + Space</code>). It’s <a href="https://github.com/Byron/dua-cli">dua</a> in interactive mode pointed at the whole file system, so you can walk down into whatever directory is the culprit, sorted biggest first, and delete from right inside it.</p>
 
-<h2 id="cliamp">Cliamp</h2>
+<h2 id="cliamp">Cliamp <a class="manual__heading-link" href="#cliamp" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.cliamp.stream/">Cliamp</a> is a retro terminal music player inspired by Winamp 2.x, complete with built-in radio stations for lo-fi beats. Launch it with <code>Super + Shift + Alt + M</code>, or from the Omarchy menu under <em>Apps</em>. Press <code>?</code> for the full keybinding list.</p>
 
-<h2 id="what-about-wi-fi-and-bluetooth">What about Wi-Fi and Bluetooth?</h2>
+<h2 id="what-about-wi-fi-and-bluetooth">What about Wi-Fi and Bluetooth? <a class="manual__heading-link" href="#what-about-wi-fi-and-bluetooth" aria-label="Link to this section">#</a></h2>
 
 <p>You won’t find TUIs for Wi-Fi and Bluetooth — those jobs belong to the Omarchy shell. Click the Wi-Fi icon in the top bar (or hit <code>Super + Ctrl + W</code>) to see networks and connect, and click the Bluetooth icon (or hit <code>Super + Ctrl + B</code>) to pair and connect devices. See <a href="../networking/">networking</a> for the full story.</p>
 
-<h2 id="adding-your-own">Adding your own</h2>
+<h2 id="adding-your-own">Adding your own <a class="manual__heading-link" href="#adding-your-own" aria-label="Link to this section">#</a></h2>
 
 <p>Any terminal program can get the full app treatment. Go to <em>Install &gt; TUI</em> in the Omarchy menu (<code>Super + Space</code>), give it a name, a launch command, a window style, and an icon, and it’ll show up in the app launcher like any other application. You can remove it again under <em>Remove &gt; TUI</em>.</p>
 

--- a/manual/unattended-installs/index.html
+++ b/manual/unattended-installs/index.html
@@ -116,7 +116,7 @@
 
 <p>This makes Omarchy great as a base image for disposable dev environments: create a VM in Proxmox or with Packer, boot it, walk away, SSH in. <code>cidata</code> is the cloud-init <code>NoCloud</code> label, so all the common virtualization tooling already knows how to attach such a drive.</p>
 
-<h2 id="the-configuration-files">The configuration files</h2>
+<h2 id="the-configuration-files">The configuration files <a class="manual__heading-link" href="#the-configuration-files" aria-label="Link to this section">#</a></h2>
 
 <p>The files are exactly what the installer’s own wizard writes, so the easiest way to get a starting set is to run one interactive install (in a VM, say) and copy what it wrote into <code>/root</code>:</p>
 
@@ -171,13 +171,13 @@
 
 <p>You can also drop in an empty file named <code>defer-provisioning</code> in place of <code>user_credentials.json</code>. That runs the same <a href="../getting-started/">prepare-for-another-owner install</a> you can trigger interactively: the machine installs with no personal details, and whoever boots it first picks their keyboard and creates their user. That’s the mode for imaging rigs, where the drive shouldn’t carry anyone’s credentials at all.</p>
 
-<h2 id="ssh-access">SSH access</h2>
+<h2 id="ssh-access">SSH access <a class="manual__heading-link" href="#ssh-access" aria-label="Link to this section">#</a></h2>
 
 <p>When <code>authorized_keys</code> is present, the install sets the keys up as the user’s <code>~/.ssh/authorized_keys</code>, enables <code>sshd</code>, and opens the firewall for it. (A stock Omarchy install ships openssh with the service disabled and the port closed, so an unattended machine would otherwise be unreachable.) The install only adds your keys — it doesn’t loosen any of the SSH daemon’s other authentication settings.</p>
 
 <p>When <code>tailscale_authkey</code> is present, the machine joins your tailnet on first boot instead: Tailscale is installed from the ISO’s bundled packages, the firewall allows the tailnet interface, and a background job runs the join as soon as the machine actually has network, retrying until it succeeds. Use a reusable, pre-authorized key so one drive image can serve many machines.</p>
 
-<h2 id="building-the-cidata-drive">Building the cidata drive</h2>
+<h2 id="building-the-cidata-drive">Building the cidata drive <a class="manual__heading-link" href="#building-the-cidata-drive" aria-label="Link to this section">#</a></h2>
 
 <p>Any filesystem with the right label works. A tiny ISO is the easy way:</p>
 
@@ -203,7 +203,7 @@ qm start 101
 
 <p>The boot order lists the disk first on purpose: the empty disk falls through to the ISO on the first boot, and the installed system boots from disk ever after.</p>
 
-<h2 id="two-caveats">Two caveats</h2>
+<h2 id="two-caveats">Two caveats <a class="manual__heading-link" href="#two-caveats" aria-label="Link to this section">#</a></h2>
 
 <p>Encrypted unattended installs aren’t fully unattended — someone still has to type the LUKS passphrase at the first boot. And the <code>disk_encryption</code> block in <code>user_configuration.json</code> carries that passphrase in plaintext, so treat a cidata drive built from an encrypted install as the secret it is.</p>
 

--- a/manual/unified-clipboard-history/index.html
+++ b/manual/unified-clipboard-history/index.html
@@ -145,7 +145,7 @@
 
 <p><em>Note that most agent harnesses will use <code>Ctrl + V</code> for pasting images, but <code>Super + V</code> for pasting text.</em></p>
 
-<h3 id="clipboard-history">Clipboard history</h3>
+<h3 id="clipboard-history">Clipboard history <a class="manual__heading-link" href="#clipboard-history" aria-label="Link to this section">#</a></h3>
 
 <p>The clipboard history is provided by the Omarchy shell and works for both text and images. You trigger it by <code>Super + Ctrl + V</code>, select your entry with return, and then that’ll be placed on the clipboard ready to paste on <code>Super + V</code>.</p>
 

--- a/manual/updates/index.html
+++ b/manual/updates/index.html
@@ -120,7 +120,7 @@
 
 <p><img src="/manual/images/update-available.webp" alt="update-available" /></p>
 
-<h3 id="four-channels">Four channels</h3>
+<h3 id="four-channels">Four channels <a class="manual__heading-link" href="#four-channels" aria-label="Link to this section">#</a></h3>
 
 <p>Omarchy is updated along four channels: stable, RC, edge, and dev. New installations start on the stable channel, which tracks the <a href="https://github.com/basecamp/omarchy/releases/">official releases</a>, as well as the <a href="https://github.com/omacom-io/omarchy-mirror">stable Omarchy Arch mirror</a> that’s running one month behind the latest, so we can catch any new incompatibilities that require config changes before they cause problems for people.</p>
 
@@ -132,15 +132,15 @@
 
 <p>You can switch between channels using <em>Update &gt; Channel</em> from the Omarchy menu (or <code>omarchy-channel-set</code> in the terminal).</p>
 
-<h3 id="firmware-updates">Firmware updates</h3>
+<h3 id="firmware-updates">Firmware updates <a class="manual__heading-link" href="#firmware-updates" aria-label="Link to this section">#</a></h3>
 
 <p>Your packages aren’t the only thing that goes stale. Many laptops and peripherals ship BIOS, SSD, and dock firmware through the Linux Vendor Firmware Service, and <em>Update &gt; Firmware</em> in the Omarchy menu will fetch and install whatever your hardware has waiting. It installs <code>fwupd</code> the first time you run it. Plenty of firmware can only be written during a reboot, so don’t be surprised to be asked for one.</p>
 
-<h3 id="warning-about-direct-pacmanyay-updates">Warning about direct pacman/yay updates</h3>
+<h3 id="warning-about-direct-pacmanyay-updates">Warning about direct pacman/yay updates <a class="manual__heading-link" href="#warning-about-direct-pacmanyay-updates" aria-label="Link to this section">#</a></h3>
 
 <p>If you’re already familiar with Arch, you might be tempted to just run <code>pacman -Syu</code> or <code>yay -Syu</code> yourself, but if you do that, you’ll miss the snapshot, migrations, and configuration updates that Omarchy runs together with new packages. That’s why Omarchy will actually stop a direct system upgrade and point you to <code>omarchy update</code> instead. (If you really know what you’re doing, the guard will tell you how to bypass it for a single transaction.)</p>
 
-<h3 id="rolling-back-bad-updates">Rolling back bad updates</h3>
+<h3 id="rolling-back-bad-updates">Rolling back bad updates <a class="manual__heading-link" href="#rolling-back-bad-updates" aria-label="Link to this section">#</a></h3>
 
 <p>If you ever have a problem after doing an update, you can rollback your system to the snapshot taken before the update. Just restart and pick the snapshot in the boot loading menu from before you started the update.</p>
 

--- a/manual/web-apps/index.html
+++ b/manual/web-apps/index.html
@@ -126,61 +126,61 @@
 
 <p>By default, Omarchy already ships with an assortment of default apps:</p>
 
-<h2 id="hey">HEY</h2>
+<h2 id="hey">HEY <a class="manual__heading-link" href="#hey" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.hey.com/">HEY</a> is an email and calendar service that serves as a great alternative to people tired of Gmail, Outlook, or Apple Mail. It’s made by <a href="https://37signals.com/">37signals</a> where Omarchy originated.</p>
 
 <p>You can start HEY Email using <code>Super + Shift + E</code>, jump straight to composing a new email using <code>Super + Shift + Alt + E</code>, and start HEY Calendar using <code>Super + Shift + C</code>.</p>
 
-<h2 id="basecamp">Basecamp</h2>
+<h2 id="basecamp">Basecamp <a class="manual__heading-link" href="#basecamp" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://basecamp.com/">Basecamp</a> is a project management service that helps small teams move faster and make more progress. Instead of patching together a mishmash of Trello, Slack, Asana, Notion, or whatever, you can have it all in one place with Basecamp. It’s made by <a href="https://37signals.com/">37signals</a> where Omarchy originated.</p>
 
 <p>You can start Basecamp using the application launcher (<code>Super + Space</code>)</p>
 
-<h2 id="chatgpt">ChatGPT</h2>
+<h2 id="chatgpt">ChatGPT <a class="manual__heading-link" href="#chatgpt" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://chatgpt.com">ChatGPT</a> is the most popular AI chat bot in the world.</p>
 
 <p>You can start ChatGPT using <code>Super + Shift + A</code>.</p>
 
-<h2 id="grok">Grok</h2>
+<h2 id="grok">Grok <a class="manual__heading-link" href="#grok" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://grok.com">Grok</a> is xAI’s chat bot.</p>
 
 <p>You can start Grok using <code>Super + Shift + Alt + A</code>.</p>
 
-<h2 id="whatsapp">WhatsApp</h2>
+<h2 id="whatsapp">WhatsApp <a class="manual__heading-link" href="#whatsapp" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://www.whatsapp.com/">WhatsApp</a> is one of the most popular messaging services in the world, and the web version is a great option for Linux.</p>
 
 <p>You can start WhatsApp using <code>Super + Shift + Alt + G</code>.</p>
 
-<h2 id="google-apps">Google apps</h2>
+<h2 id="google-apps">Google apps <a class="manual__heading-link" href="#google-apps" aria-label="Link to this section">#</a></h2>
 
 <p>Google Messages, Google Photos, Google Maps, and Google Contacts are all included as web apps too.</p>
 
 <p>You can start Google Messages using <code>Super + Shift + Ctrl + G</code>, Google Photos using <code>Super + Shift + P</code>, and Google Maps using <code>Super + Shift + S</code>. Google Contacts is available through the app launcher (<code>Super + Space</code>).</p>
 
-<h2 id="x">X</h2>
+<h2 id="x">X <a class="manual__heading-link" href="#x" aria-label="Link to this section">#</a></h2>
 
 <p>X is where news break.</p>
 
 <p>You can start X using <code>Super + Shift + X</code> and go straight to writing a new post with <code>Super + Shift + Alt + X</code>.</p>
 
-<h2 id="youtube">YouTube</h2>
+<h2 id="youtube">YouTube <a class="manual__heading-link" href="#youtube" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://youtube.com/">YouTube</a> is the most popular video platform in the world.</p>
 
 <p>You can start YouTube using <code>Super + Shift + Y</code>.</p>
 
-<h2 id="zoom">Zoom</h2>
+<h2 id="zoom">Zoom <a class="manual__heading-link" href="#zoom" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://zoom.us/">Zoom</a> is the most popular video chat system used in the US. Great connections across the world. And 40-minute meetings can be held without a paying account. Omarchy wraps Zoom’s web client, and zoom meeting links will open straight into it.</p>
 
 <p>You start Zoom using the application launcher (<code>Super + Space</code>).</p>
 
-<h2 id="discord">Discord</h2>
+<h2 id="discord">Discord <a class="manual__heading-link" href="#discord" aria-label="Link to this section">#</a></h2>
 
 <p><a href="https://discord.com/">Discord</a> is where most gaming and open source communities hang out, including <a href="https://discord.gg/tXFUdasqhY">Omarchy’s own</a>.</p>
 

--- a/manual/windows-vm/index.html
+++ b/manual/windows-vm/index.html
@@ -120,7 +120,7 @@
 
 <p><img src="/manual/images/windows-vm.webp" alt="windows-vm" /></p>
 
-<h2 id="using-it">Using it</h2>
+<h2 id="using-it">Using it <a class="manual__heading-link" href="#using-it" aria-label="Link to this section">#</a></h2>
 
 <p>Once it’s installed, launch <em>Windows</em> from the app launcher. That starts the VM if it isn’t already running and connects you over RDP, full screen. Give it 15-30 seconds on a cold start.</p>
 
@@ -135,13 +135,13 @@ omarchy windows vm stop      # shut it down
 omarchy windows vm launch    # start and connect
 </code></pre>
 
-<h2 id="sharing-files">Sharing files</h2>
+<h2 id="sharing-files">Sharing files <a class="manual__heading-link" href="#sharing-files" aria-label="Link to this section">#</a></h2>
 
 <p>The directory <code>~/Windows</code> in your home directory is automatically shared with the VM. Put files there if you want them accessible to Windows. The VM has no access to any other part of your file system, so you’re safe from anything nasty on the Windows side. Its own virtual disk lives in <code>~/.windows</code>.</p>
 
 <p>The VM’s ports are bound to localhost only, so nothing on your network can reach the Windows machine.</p>
 
-<h2 id="limits-and-licensing">Limits and licensing</h2>
+<h2 id="limits-and-licensing">Limits and licensing <a class="manual__heading-link" href="#limits-and-licensing" aria-label="Link to this section">#</a></h2>
 
 <p>There’s no GPU passthrough with this setup, so it’s not suitable for gaming or video editing. It’s a great way to run Microsoft Office or whatever else you absolutely must have.</p>
 


### PR DESCRIPTION
## Summary

- add self-linking anchors to generated h2–h6 manual headings
- reveal the anchor marker on hover while keeping it available to keyboard users
- regenerate all affected manual pages

## Verification

- rebuilt all 51 manual chapters
- verified all 253 generated subheaders have matching anchor links
- `ruby -c bin/build-manual`
- `git diff --check`

## Screenshot

Hover state:

![A hash anchor visible beside the Trackpad gestures subheader](https://raw.githubusercontent.com/omacom-io/omarchy-site/9000c339a5f1f73e61fa8d966a5b08e01c2b6c09/pr-assets/manual-heading-hover.png)