### PR TITLE
Set color-scheme to render better scrollbars in dark mode

### DIFF
--- a/assets/css/elements.css
+++ b/assets/css/elements.css
@@ -1,6 +1,7 @@
 html {
   font-size: 16px;
   scroll-behavior: smooth;
+  color-scheme: light dark;
 }
 
 html:has(dialog[open]) {


### PR DESCRIPTION
Going from that
<img width="1306" height="793" alt="image" src="https://github.com/user-attachments/assets/57ee62e9-8b75-49f4-a337-3ed07f5a7cb8" />
to this
<img width="1231" height="794" alt="image" src="https://github.com/user-attachments/assets/e8e55314-c511-4096-b91a-efab795366ff" />

