### PR TITLE
Match the manual header to the homepage and news

### DIFF
--- a/manual/ai/index.html
+++ b/manual/ai/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/backgrounds/index.html
+++ b/manual/backgrounds/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/branding/index.html
+++ b/manual/branding/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/browsers/index.html
+++ b/manual/browsers/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/coming-from-mac-or-windows/index.html
+++ b/manual/coming-from-mac-or-windows/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/commercial-apps-services/index.html
+++ b/manual/commercial-apps-services/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/common-tweaks/index.html
+++ b/manual/common-tweaks/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/development-tools/index.html
+++ b/manual/development-tools/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/dotfiles/index.html
+++ b/manual/dotfiles/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/dual-boot-install/index.html
+++ b/manual/dual-boot-install/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/faq/index.html
+++ b/manual/faq/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/filling-out-pdfs/index.html
+++ b/manual/filling-out-pdfs/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/fonts/index.html
+++ b/manual/fonts/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/gaming/index.html
+++ b/manual/gaming/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/getting-started/index.html
+++ b/manual/getting-started/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/guis/index.html
+++ b/manual/guis/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/hardware-authentication/index.html
+++ b/manual/hardware-authentication/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/hotkeys/index.html
+++ b/manual/hotkeys/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/index.html
+++ b/manual/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/keyboard-mouse-trackpad/index.html
+++ b/manual/keyboard-mouse-trackpad/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/mac-support/index.html
+++ b/manual/mac-support/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/making-your-own-theme/index.html
+++ b/manual/making-your-own-theme/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/monitors/index.html
+++ b/manual/monitors/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/navigation/index.html
+++ b/manual/navigation/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/neovim/index.html
+++ b/manual/neovim/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/networking/index.html
+++ b/manual/networking/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/notices/index.html
+++ b/manual/notices/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/omarchy-cli/index.html
+++ b/manual/omarchy-cli/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/omarchy-on/index.html
+++ b/manual/omarchy-on/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/other-packages/index.html
+++ b/manual/other-packages/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/prompt/index.html
+++ b/manual/prompt/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/reminders/index.html
+++ b/manual/reminders/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/screenshots-recording/index.html
+++ b/manual/screenshots-recording/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/security/index.html
+++ b/manual/security/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/shell-functions/index.html
+++ b/manual/shell-functions/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/shell-plugins/index.html
+++ b/manual/shell-plugins/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/shell-tools/index.html
+++ b/manual/shell-tools/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/system-sleep/index.html
+++ b/manual/system-sleep/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/system-snapshots/index.html
+++ b/manual/system-snapshots/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/terminal/index.html
+++ b/manual/terminal/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/text-extraction-dictation/index.html
+++ b/manual/text-extraction-dictation/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/the-top-bar/index.html
+++ b/manual/the-top-bar/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/themes/index.html
+++ b/manual/themes/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/toc/index.html
+++ b/manual/toc/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/toggles-idle-screensaver/index.html
+++ b/manual/toggles-idle-screensaver/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/troubleshooting/index.html
+++ b/manual/troubleshooting/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/tuis/index.html
+++ b/manual/tuis/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/unattended-installs/index.html
+++ b/manual/unattended-installs/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/unified-clipboard-history/index.html
+++ b/manual/unified-clipboard-history/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/updates/index.html
+++ b/manual/updates/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/web-apps/index.html
+++ b/manual/web-apps/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/manual/windows-vm/index.html
+++ b/manual/windows-vm/index.html
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">

--- a/templates/layout.html.erb
+++ b/templates/layout.html.erb
@@ -49,7 +49,7 @@
     </div>
 
     <header class="header">
-      <h1><a href="/manual/">The Omarchy Manual</a></h1>
+      <h1>The Manual</h1>
     </header>
 
     <main class="main">


### PR DESCRIPTION
Brings the manual's header in line with the homepage and news: the wordmark
over a plain centred line.

```
-  <h1><a href="/manual/">The Omarchy Manual</a></h1>
+  <h1>The Manual</h1>
```

The structure was already shared — all three lead with the `.pre` wordmark and
a `<header class="header">`, and the manual already loads `header.css`. The
only differences were the link around the heading and the longer wording.

Computed styles now match the homepage exactly: 18.75px, weight 300,
`rgb(122, 162, 247)`, centred, JetBrains Mono.

## Scope

`templates/layout.html.erb` and the 52 manual pages generated from it. The
pages are edited in place rather than rebuilt — running `bin/build-manual`
would re-clone the upstream manual and pull in unrelated content. The template
and its output stay in sync, so the next real rebuild is a no-op.

## Notes

- `<title>` tags still read "… — The Omarchy Manual". That is the qualified
  title for browser tabs and search results, not the visible header, so it is
  left alone.
- The news header renders at weight 400 rather than 300, because news pages
  don't load `elements.css` and `news.css` sets the weight itself. Homepage and
  manual now agree at 300; say the word if news should be brought to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
