### PR TITLE
Name the post and file when a linked asset is missing

### DIFF
--- a/bin/build-news
+++ b/bin/build-news
@@ -65,6 +65,10 @@ def load_post(file)
   date ||= Date.new(Integer(year), Integer(month), 1)
 
   assets = markdown.scan(RELATIVE_ASSET).flatten.uniq
+  assets.each do |asset|
+    next if File.file?(File.join(File.dirname(file), asset))
+    abort "#{file.delete_prefix("#{SITE_ROOT}/")} links to #{asset}, but no such file sits next to it"
+  end
   markdown = markdown.gsub(RELATIVE_ASSET) { "](/news/#{relative}/#{$1})" }
 
   html = Kramdown::Document.new(markdown, input: "GFM", hard_wrap: false, syntax_highlighter: nil).to_html


### PR DESCRIPTION
A post that links an image not sitting beside it used to fail like this:

```
fileutils.rb:2277:in 'File#initialize': No such file or directory @ rb_sysopen -
  …/content/news/2026/08/core-team.webp (Errno::ENOENT)
	from fileutils.rb:2277:in 'IO.open'
	from bin/build-news:116:in 'block (2 levels) in Object#build'
	… 12 more frames
```

Nothing in that names the post, and the path it prints is one that was never
written down — it is the post's own directory joined to the filename. Now:

```
content/news/2026/08/the-first-plugin-competition.md links to core-team.webp,
but no such file sits next to it
```

Assets are checked while the post loads, so the build stops before writing any
pages, and the message follows the same `abort` style the script already uses
for missing gems and missing titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
