### PR TITLE
Fix jdx Twitter link to @jdxcode

### DIFF
--- a/content/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor.md
+++ b/content/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor.md
@@ -5,7 +5,7 @@ author: DHH
 author_url: https://x.com/dhh
 ---
 
-Third sponsorship out the door! The Omacom Foundation is becoming a premier sponsor of [mise](https://mise.jdx.dev/), and thereby of [jdx](https://x.com/jdx), who has spent years building the tool that quietly makes managing different versions of Ruby, Node, Go a joy to manage, and gives all your agent tooling in upgrade channel that can keep up with the pace of shipping.
+Third sponsorship out the door! The Omacom Foundation is becoming a premier sponsor of [mise](https://mise.jdx.dev/), and thereby of [jdx](https://x.com/jdxcode), who has spent years building the tool that quietly makes managing different versions of Ruby, Node, Go a joy to manage, and gives all your agent tooling in upgrade channel that can keep up with the pace of shipping.
 
 If you've used Omarchy, you've used mise, whether or not you noticed. It's what manages the language runtimes, so `mise use -g ruby` gets you Ruby without a single line of PATH archaeology. But the part I care most about right now is the agents.
 

--- a/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor/index.html
+++ b/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor/index.html
@@ -71,7 +71,7 @@
         </header>
 
         <div class="news-prose">
-<p>Third sponsorship out the door! The Omacom Foundation is becoming a premier sponsor of <a href="https://mise.jdx.dev/">mise</a>, and thereby of <a href="https://x.com/jdx">jdx</a>, who has spent years building the tool that quietly makes managing different versions of Ruby, Node, Go a joy to manage, and gives all your agent tooling in upgrade channel that can keep up with the pace of shipping.</p>
+<p>Third sponsorship out the door! The Omacom Foundation is becoming a premier sponsor of <a href="https://mise.jdx.dev/">mise</a>, and thereby of <a href="https://x.com/jdxcode">jdx</a>, who has spent years building the tool that quietly makes managing different versions of Ruby, Node, Go a joy to manage, and gives all your agent tooling in upgrade channel that can keep up with the pace of shipping.</p>
 
 <p>If you’ve used Omarchy, you’ve used mise, whether or not you noticed. It’s what manages the language runtimes, so <code>mise use -g ruby</code> gets you Ruby without a single line of PATH archaeology. But the part I care most about right now is the agents.</p>
 

--- a/sponsorships/index.html
+++ b/sponsorships/index.html
@@ -102,7 +102,7 @@
 
           <p class="sponsorship__body">The tool that manages the language runtimes and, just as importantly, ships every coding-agent CLI as a lazy-loading stub. A new harness is one command away instead of a packaging project — which is what keeps Omarchy moving at the pace agent tooling actually ships.</p>
 
-          <p><a href="/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor">Read the announcement</a> &middot; <a href="https://mise.jdx.dev/">mise</a> by <a href="https://x.com/jdx">jdx</a></p>
+          <p><a href="/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor">Read the announcement</a> &middot; <a href="https://mise.jdx.dev/">mise</a> by <a href="https://x.com/jdxcode">jdx</a></p>
         </section>
 
       </div>


### PR DESCRIPTION
The mise sponsorship post and the sponsorships page linked jdx to `https://x.com/jdx`, which belongs to an unrelated account (a NYC photographer). Jeff Dickey's actual handle is [@jdxcode](https://x.com/jdxcode), as listed on mise's own about page.

Updated in:
- `content/news/2026/08/omacom-foundation-to-be-premier-mise-sponsor.md`
- `news/2026/08/omacom-foundation-to-be-premier-mise-sponsor/index.html` (generated)
- `sponsorships/index.html`