### PR TITLE
Sort Mini Jcw and Neptune Blue into the grid

### DIFF
--- a/themes/index.html
+++ b/themes/index.html
@@ -401,13 +401,13 @@
 </figure>
 
 <figure class="themes__theme">
-  <a href="https://github.com/davydotcom/omarchy-mini-jcw-theme"><img src="/assets/themes/mini-jcw.webp" alt="Mini Jcw theme" loading="lazy" decoding="async"></a>
-  <figcaption><a href="https://github.com/davydotcom/omarchy-mini-jcw-theme">Mini Jcw</a></figcaption>
+  <a href="https://github.com/hipsterusername/omarchy-milkmatcha-light-theme"><img src="/assets/themes/milky-matcha.webp" alt="Milky Matcha theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/hipsterusername/omarchy-milkmatcha-light-theme">Milky Matcha</a></figcaption>
 </figure>
 
 <figure class="themes__theme">
-  <a href="https://github.com/hipsterusername/omarchy-milkmatcha-light-theme"><img src="/assets/themes/milky-matcha.webp" alt="Milky Matcha theme" loading="lazy" decoding="async"></a>
-  <figcaption><a href="https://github.com/hipsterusername/omarchy-milkmatcha-light-theme">Milky Matcha</a></figcaption>
+  <a href="https://github.com/davydotcom/omarchy-mini-jcw-theme"><img src="/assets/themes/mini-jcw.webp" alt="Mini Jcw theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/davydotcom/omarchy-mini-jcw-theme">Mini Jcw</a></figcaption>
 </figure>
 
 <figure class="themes__theme">
@@ -441,13 +441,13 @@
 </figure>
 
 <figure class="themes__theme">
-  <a href="https://github.com/davydotcom/omarchy-neptune-blue-theme"><img src="/assets/themes/neptune-blue.webp" alt="Neptune Blue theme" loading="lazy" decoding="async"></a>
-  <figcaption><a href="https://github.com/davydotcom/omarchy-neptune-blue-theme">Neptune Blue</a></figcaption>
+  <a href="https://github.com/RiO7MAKK3R/omarchy-neovoid-theme"><img src="/assets/themes/neovoid.webp" alt="Neovoid theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/RiO7MAKK3R/omarchy-neovoid-theme">Neovoid</a></figcaption>
 </figure>
 
 <figure class="themes__theme">
-  <a href="https://github.com/RiO7MAKK3R/omarchy-neovoid-theme"><img src="/assets/themes/neovoid.webp" alt="Neovoid theme" loading="lazy" decoding="async"></a>
-  <figcaption><a href="https://github.com/RiO7MAKK3R/omarchy-neovoid-theme">Neovoid</a></figcaption>
+  <a href="https://github.com/davydotcom/omarchy-neptune-blue-theme"><img src="/assets/themes/neptune-blue.webp" alt="Neptune Blue theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/davydotcom/omarchy-neptune-blue-theme">Neptune Blue</a></figcaption>
 </figure>
 
 <figure class="themes__theme">


### PR DESCRIPTION
The comment above the grid asks for alphabetical order, and [#51](https://github.com/omacom-io/omarchy-site/pull/51) placed both of its themes one slot early — `Milky Matcha` sorts before `Mini Jcw`, and `Neovoid` before `Neptune Blue`. Each swaps with the neighbour it passed.

Nine other pairs in the grid were already out of order before that pull request and are left alone here, so the diff is only the two this fixes.

🤖 Generated by Opus 5 in Claude Code.