### PR TITLE
Add arrow-key navigation to manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ checkout to build without hitting GitHub: `bin/build-manual ../omarchy/manual`.
 The same build writes `manual/search-index.json` — one entry per heading, so results link
 straight to the section that matched. `assets/js/modules/search.js` fetches it the first
 time someone reaches for the box in the header and matches in the browser; there is no
-search service and nothing to run. Press `/` anywhere in the manual to search.
+search service and nothing to run. Press `/` anywhere in the manual to search. On a
+chapter, use the left and right arrow keys to move to the previous or next chapter.

--- a/assets/js/manual.js
+++ b/assets/js/manual.js
@@ -1,7 +1,9 @@
 import * as search from './modules/search.js';
+import * as navigation from './modules/manual-navigation.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
   search.ready();
+  navigation.ready();
 
 });

--- a/assets/js/modules/manual-navigation.js
+++ b/assets/js/modules/manual-navigation.js
@@ -12,10 +12,11 @@ function ready() {
 
     var page = pages[e.key];
 
-    if(page) {
+    // Object.prototype means a key like 'constructor' would look like a hit
+    if(page instanceof HTMLAnchorElement) {
 
       e.preventDefault();
-      window.location = page.href;
+      window.location.href = page.href;
 
     }
 

--- a/assets/js/modules/manual-navigation.js
+++ b/assets/js/modules/manual-navigation.js
@@ -1,0 +1,26 @@
+function ready() {
+
+  var pages = {
+    ArrowLeft: document.querySelector('a[rel="prev"]'),
+    ArrowRight: document.querySelector('a[rel="next"]')
+  };
+
+  document.addEventListener('keydown', (e) => {
+
+    if(e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+    if(e.target != document.body) return;
+
+    var page = pages[e.key];
+
+    if(page) {
+
+      e.preventDefault();
+      window.location = page.href;
+
+    }
+
+  });
+
+}
+
+export { ready };


### PR DESCRIPTION
Adds Left and Right Arrow keyboard navigation between manual chapters using the existing previous and next pagination links.

The shortcuts only apply during normal page reading, leaving focused controls and browser modifier shortcuts untouched.