### PR TITLE
Restore Noir Dawn, and sort Oligarchy after Nujabes

### DIFF
--- a/themes/index.html
+++ b/themes/index.html
@@ -496,13 +496,18 @@
 </figure>
 
 <figure class="themes__theme">
-  <a href="https://github.com/EF-Code/omarchy-oligarchy-theme"><img src="/assets/themes/oligarchy.webp" alt="Oligarchy theme" loading="lazy" decoding="async"></a>
-  <figcaption><a href="https://github.com/EF-Code/omarchy-oligarchy-theme">Oligarchy</a></figcaption>
+  <a href="https://github.com/tahadx/omarchy-noir-dawn-theme"><img src="/assets/themes/noir-dawn.webp" alt="Noir Dawn theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/tahadx/omarchy-noir-dawn-theme">Noir Dawn</a></figcaption>
 </figure>
 
 <figure class="themes__theme">
   <a href="https://github.com/HalmyLyseas/omarchy-nujabes-theme"><img src="/assets/themes/nujabes.webp" alt="Nujabes theme" loading="lazy" decoding="async"></a>
   <figcaption><a href="https://github.com/HalmyLyseas/omarchy-nujabes-theme">Nujabes</a></figcaption>
+</figure>
+
+<figure class="themes__theme">
+  <a href="https://github.com/EF-Code/omarchy-oligarchy-theme"><img src="/assets/themes/oligarchy.webp" alt="Oligarchy theme" loading="lazy" decoding="async"></a>
+  <figcaption><a href="https://github.com/EF-Code/omarchy-oligarchy-theme">Oligarchy</a></figcaption>
 </figure>
 
 <figure class="themes__theme">


### PR DESCRIPTION
Noir Dawn has not been listed since [43003ba](https://github.com/omacom-io/omarchy-site/commit/43003ba33269a1016b53c06f47474476c4ba5849) ([#69](https://github.com/omacom-io/omarchy-site/pull/69)). That branch was opened before [#44](https://github.com/omacom-io/omarchy-site/pull/44) merged, so it still carried Noir Dawn's figure block in the slot it wanted, and squashing it **replaced** that entry instead of adding one:

```diff
-  <a href="https://github.com/tahadx/omarchy-noir-dawn-theme">...Noir Dawn...
+  <a href="https://github.com/EF-Code/omarchy-oligarchy-theme">...Oligarchy...
```

GitHub reported #69 as mergeable because there was no textual conflict — both branches simply wrote the same region, and the newer one won. `assets/themes/noir-dawn.webp` stayed in the repository with nothing referencing it, which is what turned it up: the grid had 147 entries and 148 files.

Oligarchy also landed one slot early, so it moves down one — `Nujabes` sorts before it. The order is now Noir, Noir Dawn, Nujabes, Oligarchy.

The nine pairs that were already out of alphabetical order before any of this are left alone.

🤖 Generated by Opus 5 in Claude Code.