### PR TITLE
Add homepage subtext: the malleable computer for the age of agents

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -9,6 +9,15 @@
   text-align: center;
 }
 
+.header__subtext {
+  font-style: italic;
+  justify-self: center;
+  margin-top: var(--space-neutral);
+  max-width: 46em;
+  text-align: center;
+  text-wrap: pretty;
+}
+
 
 
 @media(min-width: 64em) {

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -18,6 +18,11 @@
   text-wrap: pretty;
 }
 
+.header__subtext a,
+.header__subtext a:hover {
+  color: inherit;
+}
+
 
 
 @media(min-width: 64em) {

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
 
     <header class="header">
       <h1>Beautiful, Fun &amp; Opinionated Linux by <a href="https://dhh.dk">DHH</a></h1>
+      <p class="header__subtext">The malleable computer in the age of agents. Everything in Omarchy is a text file, a script, or open code, so all of it bends to your will. Tweak it by hand or turn an agent loose on it. Either way, the machine is yours to mold.</p>
     </header>
 
     <nav class="nav">

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
     <header class="header">
       <h1>Beautiful, Fun &amp; Opinionated Linux by <a href="https://dhh.dk">DHH</a></h1>
-      <p class="header__subtext">The malleable computer in the age of agents. Everything in Omarchy is a text file, a script, or open code, so all of it bends to your will. Tweak it by hand or turn an agent loose on it. Either way, the machine is yours to mold.</p>
+      <p class="header__subtext">The malleable computer for the age of agents. You get total control and can change every aspect of the operating system to your whims, but out-of-the-box it's ready to go without any setup or toil. <a href="https://omarchs.fyi">Be the Omarch!</a></p>
     </header>
 
     <nav class="nav">


### PR DESCRIPTION
Adds a subtext under the homepage heading introducing Omarchy as the malleable computer for the age of agents, with a link to omarchs.fyi kept in body color at all times. Styled to match the AIR page lede (italic, centered, 46em measure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)