### PR TITLE
Say OS instead of computer in the homepage subtext

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
     <header class="header">
       <h1>Beautiful, Fun &amp; Opinionated Linux by <a href="https://dhh.dk">DHH</a></h1>
-      <p class="header__subtext">The malleable computer for the age of agents. You get total control and can change every aspect of the operating system to your whims, but out-of-the-box it's ready to go without any setup or toil. <a href="https://omarchs.fyi">Be the Omarch!</a></p>
+      <p class="header__subtext">The malleable OS for the age of agents. You get total control and can change every aspect of the operating system to your whims, but out-of-the-box it's ready to go without any setup or toil. <a href="https://omarchs.fyi">Be the Omarch!</a></p>
     </header>
 
     <nav class="nav">


### PR DESCRIPTION
Changes the homepage subtext opener to "The malleable OS for the age of agents."

🤖 Generated with [Claude Code](https://claude.com/claude-code)