### PR TITLE
Update the security page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v5
         with:
           path: .
+          include-hidden-files: true
 
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@omarchy.org
+Expires: 2027-08-29T23:59:59Z
+Preferred-Languages: en
+Canonical: https://omarchy.org/.well-known/security.txt
+Policy: https://omarchy.org/security
+Acknowledgments: https://omarchy.org/security/credits

--- a/security/credits/index.html
+++ b/security/credits/index.html
@@ -79,7 +79,7 @@
             </article>
           </div>
 
-          <p class="team__note">Found something? <a href="/security/">Report it privately</a> and you&rsquo;ll end up here too.</p>
+          <p class="team__note">Found something? <a href="/security/">Report it privately</a>. The first reporter of a confirmed vulnerability is credited here.</p>
         </section>
 
       </div>

--- a/security/index.html
+++ b/security/index.html
@@ -80,13 +80,22 @@
         </section>
 
         <section class="security__section">
+          <h2>What is a vulnerability?</h2>
+          <p>We consider a bug a security vulnerability when it can be exploited to cross a meaningful security boundary: an untrusted or lower-privileged party gains access, permissions, or control they didn&rsquo;t already have.</p>
+
+          <p>Code that could be more robust but does not cross a security boundary is an improvement rather than a security vulnerability. We may still merge a proposed fix and credit the reporter in our release notes.</p>
+
+          <p>Eligibility for our <a href="/security/credits/">security credits</a> page depends on whether a report identifies a confirmed security vulnerability, not on its severity.</p>
+        </section>
+
+        <section class="security__section">
           <h2>What to include</h2>
           <p>Give us enough information to understand and reproduce the issue:</p>
 
           <ul>
             <li>The affected component and Omarchy version.</li>
-            <li>Steps to reproduce the vulnerability.</li>
-            <li>The impact and any proof of concept you have.</li>
+            <li>An explanation of what an attacker can do before and after exploitation.</li>
+            <li>Steps to reproduce the issue and any proof of concept.</li>
             <li>Your preferred contact details for follow-up.</li>
           </ul>
         </section>
@@ -107,7 +116,8 @@
 
         <section class="security__section">
           <h2>Credits</h2>
-          <p>Everyone who has reported a security issue privately and given us the chance to ship a fix is thanked on the <a href="/security/credits/">security credits</a> page.</p>
+          <p>Researchers who privately report a confirmed security vulnerability and give us the chance to ship a fix are thanked on the <a href="/security/credits/">security credits</a> page. Accepted improvements that don&rsquo;t cross a security boundary may still be credited in our release notes.</p>
+          <p>Credits link to each reporter&rsquo;s X profile and show their avatar. For duplicate reports, only the first reporter is eligible for credit.</p>
         </section>
 
         <section class="security__section">


### PR DESCRIPTION
Clarifies what Omarchy considers a security vulnerability, including credit eligibility and duplicate-report handling.

Also adds /.well-known/security.txt pointing researchers to our reporting email, policy, and credits page.