### PR TITLE
Rewrite /omakub copy in the house voice

### DIFF
--- a/omakub/index.html
+++ b/omakub/index.html
@@ -59,8 +59,8 @@
     </div>
 
     <header class="header">
-      <h1>The story of Omakub</h1>
-      <p class="header__subtext">Before Omarchy, there was Omakub: an omakase developer setup for Ubuntu. One command turned a fresh installation into a fully-configured, beautiful, and modern web development system. No config quiz, no weekend lost to dotfiles. The chef chooses, you eat.</p>
+      <h1>It began with Omakub</h1>
+      <p class="header__subtext">Before Omarchy, there was Omakub. A humble omakase developer setup for Ubuntu. One command turned a fresh installation into as good a base for developers as the rather rigid and limited base would allow.</p>
     </header>
 
     <main class="main">
@@ -72,34 +72,34 @@
         </section>
 
         <section class="omakub__section">
-          <h2>One command</h2>
-          <p>Omakub was born in the summer of 2024, when I went all-in on Linux and refused to accept that the first day had to be spent copying dotfiles and spelunking through wikis. So it all became one script: run it on a fresh Ubuntu, go make an espresso, and come back to a complete developer machine. Neovim, Zellij, Alacritty, lazygit, lazydocker, all the modern command-line replacements, and themes that carried through the entire system. Plus an <code>omakub</code> menu to switch themes and fonts or install more, so nobody had to remember anything.</p>
+          <h2>Early Aesthetics</h2>
 
           <figure class="omakub__figure">
             <img src="/omakub/omakub-desktop.webp" width="1600" height="900" alt="The Omakub desktop: GNOME overview with a misty forest wallpaper, dock, and workspaces" loading="lazy">
-            <figcaption>Stock GNOME underneath, but tuned until it felt intentional.</figcaption>
+            <figcaption>There's only so much you can do with GNOME, but I did what I could.</figcaption>
           </figure>
 
           <figure class="omakub__figure">
             <img src="/omakub/omakub-neovim.webp" width="1600" height="900" alt="Neovim and a terminal running inside Zellij, showing the Omakub file tree" loading="lazy">
-            <figcaption>Neovim and Zellij out of the box, configs already done.</figcaption>
+            <figcaption>Neovim and Zellij out of the box.</figcaption>
           </figure>
 
           <figure class="omakub__figure">
             <img src="/omakub/omakub-theme.webp" width="1600" height="900" alt="The omakub theme command in a terminal, with the Omakub ASCII banner" loading="lazy">
-            <figcaption>One command to re-theme the whole machine. All stills from the <a href="https://videos.37signals.com/omakub/omakub.mp4">launch video</a>.</figcaption>
+            <figcaption>Even then, one command could re-theme multiple apps.</figcaption>
           </figure>
         </section>
 
         <section class="omakub__section">
           <h2>The road to Omarchy</h2>
-          <p>Omakub proved the thesis: give developers a beautiful, complete Linux out of the box, and they&rsquo;ll show up! Tens of thousands did. But it also found the ceiling. Omakub was a layer of opinion on top of Ubuntu and GNOME, and those come with strong opinions of their own. The ideas I actually cared about — tiling, everything on the keyboard, a system that treats the terminal as the center of the universe — kept fighting the platform instead of flowing from it.</p>
+          <p>Omakub proved the thesis: give developers a beautiful, complete Linux out of the box, and they&rsquo;ll show up! Tens of thousands did.</p>
+          <p>But it also found the ceiling. Omakub was a layer of opinion on top of Ubuntu and GNOME, and those come with strong opinions of their own. The ideas I actually cared about — tiling, everything on the keyboard, a system that treats the terminal as the center of the universe — kept fighting the platform instead of flowing from it.</p>
           <p>So the omakase moved from Ubuntu to Arch, from GNOME to Hyprland, and became <a href="/">Omarchy</a>. Not a layer on top of somebody else&rsquo;s distribution, but the whole meal. Everything Omakub was reaching for, without asking anyone&rsquo;s permission first.</p>
         </section>
 
         <section class="omakub__section">
-          <h2>The thread continues</h2>
-          <p>Omakub itself is now retired. The repositories are archived on GitHub — <a href="https://github.com/omacom/omakub">omakub</a> and <a href="https://github.com/omacom/omakub-site">omakub-site</a> — and omakub.org points here. But good ideas don&rsquo;t retire, they get forked! <a href="https://omabuntu.omakasui.org/">Omabuntu</a> is a community fork continuing on the omakase-Ubuntu thread. If Arch is a step too far and Ubuntu is home, that&rsquo;s where you should go.</p>
+          <h2>The retirement home is staffed</h2>
+          <p>Omakub itself is now retired. The repositories are archived on GitHub — <a href="https://github.com/omacom/omakub">omakub</a> and <a href="https://github.com/omacom/omakub-site">omakub-site</a>. But good ideas don&rsquo;t retire, they get forked! <a href="https://omabuntu.omakasui.org/">Omabuntu</a> is a community fork continuing on the omakase-Ubuntu thread. If Arch is a step too far and Ubuntu is home, that&rsquo;s where you should go.</p>
           <p>Thanks to everyone who ran it, contributed to it, and showed off their desktops. Omakub walked so Omarchy could run.</p>
         </section>
 

--- a/omakub/index.html
+++ b/omakub/index.html
@@ -32,7 +32,6 @@
     <link rel="stylesheet" type="text/css" href="/assets/css/root.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/fonts.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/elements.css">
-    <link rel="stylesheet" type="text/css" href="/assets/css/button.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/header.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/main.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/pre.css">
@@ -102,10 +101,6 @@
           <h2>The thread continues</h2>
           <p>Omakub itself is now retired. The repositories are archived on GitHub — <a href="https://github.com/omacom/omakub">omakub</a> and <a href="https://github.com/omacom/omakub-site">omakub-site</a> — and omakub.org points here. But good ideas don&rsquo;t retire, they get forked! <a href="https://omabuntu.omakasui.org/">Omabuntu</a> is a community fork continuing on the omakase-Ubuntu thread. If Arch is a step too far and Ubuntu is home, that&rsquo;s where you should go.</p>
           <p>Thanks to everyone who ran it, contributed to it, and showed off their desktops. Omakub walked so Omarchy could run.</p>
-
-          <a class="button" href="https://omabuntu.omakasui.org/">
-            <span>Visit Omabuntu</span>
-          </a>
         </section>
 
       </div>

--- a/omakub/index.html
+++ b/omakub/index.html
@@ -60,6 +60,7 @@
 
     <header class="header">
       <h1>The story of Omakub</h1>
+      <p class="header__subtext">Before Omarchy, there was Omakub: an omakase developer setup for Ubuntu. One command turned a fresh installation into a fully-configured, beautiful, and modern web development system. No config quiz, no weekend lost to dotfiles. The chef chooses, you eat.</p>
     </header>
 
     <main class="main">
@@ -68,7 +69,6 @@
 
         <section class="omakub__intro">
           <img class="omakub__hero" src="/omakub/omakub.png" width="2400" height="1260" alt="Omakub — turn a fresh Ubuntu installation into a fully-configured, beautiful, and modern web development system by running a single command">
-          <p>Before Omarchy, there was Omakub: an omakase developer setup for Ubuntu. One command turned a fresh installation into a fully-configured, beautiful, and modern web development system. No config quiz, no weekend lost to dotfiles. The chef chooses, you eat.</p>
         </section>
 
         <section class="omakub__section">

--- a/omakub/index.html
+++ b/omakub/index.html
@@ -69,21 +69,21 @@
 
         <section class="omakub__intro">
           <img class="omakub__hero" src="/omakub/omakub.png" width="2400" height="1260" alt="Omakub — turn a fresh Ubuntu installation into a fully-configured, beautiful, and modern web development system by running a single command">
-          <p>Before Omarchy, there was Omakub: an omakase developer setup for Ubuntu. One command turned a fresh installation into a fully-configured, beautiful, and modern web development system. No config quiz, no yak shave. The chef chooses, you eat.</p>
+          <p>Before Omarchy, there was Omakub: an omakase developer setup for Ubuntu. One command turned a fresh installation into a fully-configured, beautiful, and modern web development system. No config quiz, no weekend lost to dotfiles. The chef chooses, you eat.</p>
         </section>
 
         <section class="omakub__section">
-          <h2>What it was</h2>
-          <p>Omakub launched in the summer of 2024 as an opinionated take on what Linux could be at its best. It layered a curated selection on top of stock Ubuntu and GNOME: Neovim, Zellij, Alacritty, lazygit, lazydocker, the modern command-line replacements, a set of hand-tuned themes that carried through the entire system, and an <code>omakub</code> menu for switching themes and fonts or installing more.</p>
+          <h2>One command</h2>
+          <p>Omakub was born in the summer of 2024, when I went all-in on Linux and refused to accept that the first day had to be spent copying dotfiles and spelunking through wikis. So it all became one script: run it on a fresh Ubuntu, go make an espresso, and come back to a complete developer machine. Neovim, Zellij, Alacritty, lazygit, lazydocker, all the modern command-line replacements, and themes that carried through the entire system. Plus an <code>omakub</code> menu to switch themes and fonts or install more, so nobody had to remember anything.</p>
 
           <figure class="omakub__figure">
             <img src="/omakub/omakub-desktop.webp" width="1600" height="900" alt="The Omakub desktop: GNOME overview with a misty forest wallpaper, dock, and workspaces" loading="lazy">
-            <figcaption>The Omakub desktop: stock GNOME, tuned until it felt intentional.</figcaption>
+            <figcaption>Stock GNOME underneath, but tuned until it felt intentional.</figcaption>
           </figure>
 
           <figure class="omakub__figure">
             <img src="/omakub/omakub-neovim.webp" width="1600" height="900" alt="Neovim and a terminal running inside Zellij, showing the Omakub file tree" loading="lazy">
-            <figcaption>Neovim and Zellij out of the box, with configs already done.</figcaption>
+            <figcaption>Neovim and Zellij out of the box, configs already done.</figcaption>
           </figure>
 
           <figure class="omakub__figure">
@@ -93,14 +93,15 @@
         </section>
 
         <section class="omakub__section">
-          <h2>How it led to Omarchy</h2>
-          <p>Omakub proved the thesis: given a beautiful, complete setup out of the box, developers would give Linux a real chance. But it also found the ceiling. Layering opinion on top of Ubuntu and GNOME meant fighting the platform&rsquo;s own opinions, and the most interesting ideas — tiling, total keyboard control, a system built around the terminal — wanted a foundation that didn&rsquo;t push back.</p>
-          <p>So the omakase moved from Ubuntu to Arch, from GNOME to Hyprland, and became <a href="/">Omarchy</a>. Not a layer on top of a distribution, but the whole meal. Everything Omakub was reaching for, without the compromises.</p>
+          <h2>The road to Omarchy</h2>
+          <p>Omakub proved the thesis: give developers a beautiful, complete Linux out of the box, and they&rsquo;ll show up! Tens of thousands did. But it also found the ceiling. Omakub was a layer of opinion on top of Ubuntu and GNOME, and those come with strong opinions of their own. The ideas I actually cared about — tiling, everything on the keyboard, a system that treats the terminal as the center of the universe — kept fighting the platform instead of flowing from it.</p>
+          <p>So the omakase moved from Ubuntu to Arch, from GNOME to Hyprland, and became <a href="/">Omarchy</a>. Not a layer on top of somebody else&rsquo;s distribution, but the whole meal. Everything Omakub was reaching for, without asking anyone&rsquo;s permission first.</p>
         </section>
 
         <section class="omakub__section">
           <h2>The thread continues</h2>
-          <p>Omakub itself is now retired, and its repositories are archived on GitHub: <a href="https://github.com/omacom/omakub">omakub</a> and <a href="https://github.com/omacom/omakub-site">omakub-site</a>. But the idea of an omakase Ubuntu lives on in <a href="https://omabuntu.omakasui.org/">Omabuntu</a>, a community fork that&rsquo;s continuing on that thread.</p>
+          <p>Omakub itself is now retired. The repositories are archived on GitHub — <a href="https://github.com/omacom/omakub">omakub</a> and <a href="https://github.com/omacom/omakub-site">omakub-site</a> — and omakub.org points here. But good ideas don&rsquo;t retire, they get forked! <a href="https://omabuntu.omakasui.org/">Omabuntu</a> is a community fork continuing on the omakase-Ubuntu thread. If Arch is a step too far and Ubuntu is home, that&rsquo;s where you should go.</p>
+          <p>Thanks to everyone who ran it, contributed to it, and showed off their desktops. Omakub walked so Omarchy could run.</p>
 
           <a class="button" href="https://omabuntu.omakasui.org/">
             <span>Visit Omabuntu</span>


### PR DESCRIPTION
Follow-up to #120: rewrites the page copy in the style of the /news posts — first person, punchier sections (One command / The road to Omarchy / The thread continues), and a proper kicker to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)