### PR TITLE
fix: invalid `rgb()` syntax that silently dropped three borders

### DIFF
--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -12,7 +12,7 @@
 }
 
 .footer__section p {
-  color: rgb(var(--rgb-terminal-white) / 0.6);
+  color: rgb(var(--rgb-terminal-white), 0.6);
   font-size: var(--font-size-small);
   font-weight: 500;
   line-height: 2em;

--- a/assets/css/news.css
+++ b/assets/css/news.css
@@ -9,7 +9,7 @@
   --news-measure: 51.5rem;
   --news-space: 2.75rem;
   --news-space-tight: 0.5rem;
-  --news-border-color: rgb(var(--rgb-terminal-black) / 0.8);
+  --news-border-color: rgb(var(--rgb-terminal-black), 0.8);
   --news-border-width: max(1px, 0.0625em);
 
   background: var(--color-background-night);

--- a/assets/css/root.css
+++ b/assets/css/root.css
@@ -22,7 +22,7 @@
   --color-turquoise: rgb(var(--rgb-turquoise));
   --color-white: rgb(var(--rgb-white));
 
-  --border-color: rgb(var(--rgb-terminal-black) / 0.8);
+  --border-color: rgb(var(--rgb-terminal-black), 0.8);
   --border-width: max(1px, 0.0625em);
 
   --font-family: 'JetBrains Mono', monospace;


### PR DESCRIPTION
It happens to me too quite often!

`--rgb-*` custom properties in [assets/css/root.css](./assets/css/root.css) store channels comma-separated:

```css
--rgb-terminal-black: 65, 72, 104;
```

Three declarations then interpolate that into the modern slash-alpha rgb() form:

```css
rgb(var(--rgb-terminal-black) / 0.8)
```

This expands at computed-value time to `rgb(65, 72, 104 / 0.8)`.

It does not accept a mix of legacy and modern syntaxes.

Fix: change the separator from `/` to `,` in the three affected declarations, so we also preserve the custom CSS variables:

```diff
-  --border-color: rgb(var(--rgb-terminal-black) / 0.8);
+  --border-color: rgb(var(--rgb-terminal-black), 0
```

News cards on [omarchy.org/news](https://omarchy.org/news/) now render their 1px border, and the "Read more" pill link shows its outline (previously invisible since border-radius had no border to round).